### PR TITLE
Basic PCSC support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "hex-literal",
  "num-traits",
  "num_enum",
+ "pcsc",
  "rand",
  "ruint",
  "rusb",
@@ -803,6 +804,25 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pcsc"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd833ecf8967e65934c49d3521a175929839bf6d0e497f3bd0d3a2ca08943da"
+dependencies = [
+ "bitflags",
+ "pcsc-sys",
+]
+
+[[package]]
+name = "pcsc-sys"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ef017e15d2e5592a9e39a346c1dbaea5120bab7ed7106b210ef58ebd97003"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "pem-rfc7468"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ hex = "0.4.3"
 hex-literal = "0.4.1"
 num-traits = "0.2.19"
 num_enum = "0.7.3"
+pcsc = "2.9"
 rand = "0.8.5"
 ruint = { version = "1.12.4", features = [
     "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ opt-level = 2
 opt-level = 3
 
 [features]
-default = ["proxmark3"]
+default = ["proxmark3", "pcsc"]
 proxmark3 = ["rusb"]
 
 [dependencies]
@@ -57,7 +57,7 @@ hex = "0.4.3"
 hex-literal = "0.4.1"
 num-traits = "0.2.19"
 num_enum = "0.7.3"
-pcsc = "2.9"
+pcsc = { version = "2.9", optional = true }
 rand = "0.8.5"
 ruint = { version = "1.12.4", features = [
     "rand",

--- a/src/emrtd/chip_access.rs
+++ b/src/emrtd/chip_access.rs
@@ -1,0 +1,18 @@
+//! Chip access procedure to authenticate the inspection system
+//! Reference ICAO 9303-11 4.2
+
+use {super::Emrtd, crate::asn1::emrtd::EfCardAccess, anyhow::Result, rand::Rng};
+
+impl Emrtd {
+    /// Establish PACE or BAC with the eMRTD chip
+    pub fn chip_access(&mut self, rng: &mut impl Rng, mrz: &str) -> Result<()> {
+        let file = self.read_cached::<EfCardAccess>();
+        match file {
+            Ok(access) => {
+                let info = access.pace_info()?;
+                self.pace(rng, &mrz, info)
+            }
+            _ => self.basic_access_control(rng, &mrz),
+        }
+    }
+}

--- a/src/nfc/mod.rs
+++ b/src/nfc/mod.rs
@@ -1,3 +1,4 @@
+mod pcsc;
 mod proxmark3;
 
 use {crate::iso7816::StatusWord, anyhow::Result};
@@ -6,6 +7,7 @@ use {crate::iso7816::StatusWord, anyhow::Result};
 pub enum CardType {
     A(CardTypeA),
     B(CardTypeB),
+    Abstract,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
@@ -45,6 +47,15 @@ pub trait NfcReader {
     fn send_apdu(&mut self, apdu: &[u8]) -> Result<(StatusWord, Vec<u8>)>;
 }
 
+/// Tries to connect to either the PCSC daemon or a Proxmark3 device
 pub fn connect_reader() -> Result<Box<dyn NfcReader>> {
-    Ok(Box::new(proxmark3::Proxmark3::new()?))
+    match pcsc::PCSC::init() {
+        Ok(reader) => Ok(Box::new(reader) as Box<dyn NfcReader>),
+        Err(pcsc_err) => match proxmark3::Proxmark3::new() {
+            Ok(reader) => Ok(Box::new(reader) as Box<dyn NfcReader>),
+            Err(pm3_err) => Err(anyhow::anyhow!(
+                "Failed to connect to any reader:\n  PCSC: {pcsc_err}\n  Proxmark3: {pm3_err}"
+            ))
+        }
+    }
 }

--- a/src/nfc/mod.rs
+++ b/src/nfc/mod.rs
@@ -49,13 +49,34 @@ pub trait NfcReader {
 
 /// Tries to connect to either the PCSC daemon or a Proxmark3 device
 pub fn connect_reader() -> Result<Box<dyn NfcReader>> {
+    let mut errors = Vec::new();
+
+    #[cfg(feature = "pcsc")]
+    // Connect to the daemon
     match pcsc::PCSC::init() {
-        Ok(reader) => Ok(Box::new(reader) as Box<dyn NfcReader>),
-        Err(pcsc_err) => match proxmark3::Proxmark3::new() {
-            Ok(reader) => Ok(Box::new(reader) as Box<dyn NfcReader>),
-            Err(pm3_err) => Err(anyhow::anyhow!(
-                "Failed to connect to any reader:\n  PCSC: {pcsc_err}\n  Proxmark3: {pm3_err}"
-            ))
+        Ok(mut reader) => {
+            // Connect to the card
+            match reader.connect() {
+                Ok(()) => return Ok(Box::new(reader) as Box<dyn NfcReader>),
+                Err(e) => errors.push(("PCSC", e)),
+            }
         }
+        Err(e) => errors.push(("PCSC", e)),
     }
+
+    #[cfg(feature = "proxmark3")]
+    match proxmark3::Proxmark3::new() {
+        Ok(reader) => return Ok(Box::new(reader) as Box<dyn NfcReader>),
+        Err(e) => errors.push(("Proxmark3", e)),
+    }
+
+    let error_msg = errors
+        .iter()
+        .map(|(name, err)| format!("  {name}: {err}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Err(anyhow::anyhow!(
+        "Failed connecting to card using any reader:\n{error_msg}"
+    ))
 }

--- a/src/nfc/pcsc.rs
+++ b/src/nfc/pcsc.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pcsc")]
+
 use {
     super::{CardType, NfcReader},
     crate::iso7816::StatusWord,
@@ -15,19 +17,24 @@ impl PCSC {
         // Establish a PC/SC context
         let ctx = Context::establish(Scope::User)
             .map_err(|e| anyhow!("Failed to establish context: {e}"))?;
-        Ok(PCSC {ctx, card: None})
+        Ok(PCSC { ctx, card: None })
     }
 
     pub fn connect(&mut self) -> Result<()> {
         // List available readers
         let mut readers_buf = [0; 2048];
-        let mut readers = self.ctx
+        let mut readers = self
+            .ctx
             .list_readers(&mut readers_buf)
             .map_err(|e| anyhow!("Failed to list readers: {e}"))?;
 
         // Find first reader with card
         let card = readers
-            .find_map(|reader| self.ctx.connect(reader, ShareMode::Shared, Protocols::ANY).ok())
+            .find_map(|reader| {
+                self.ctx
+                    .connect(reader, ShareMode::Shared, Protocols::ANY)
+                    .ok()
+            })
             .ok_or_else(|| anyhow!("No card found"))?;
 
         self.card = Some(card);
@@ -36,7 +43,9 @@ impl PCSC {
     }
 
     pub fn send(&mut self, apdu: &[u8]) -> Result<(StatusWord, Vec<u8>)> {
-        let Some(card) = &self.card else { bail!("Not connected to a card") };
+        let Some(card) = &self.card else {
+            bail!("Not connected to a card")
+        };
         let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
         let rapdu = card
             .transmit(apdu, &mut rapdu_buf)
@@ -53,8 +62,12 @@ impl PCSC {
         Ok(())
     }
 
-    pub fn ctx(&self) -> &Context { &self.ctx }
-    pub fn ctx_mut(&mut self) -> &mut Context { &mut self.ctx }
+    pub fn ctx(&self) -> &Context {
+        &self.ctx
+    }
+    pub fn ctx_mut(&mut self) -> &mut Context {
+        &mut self.ctx
+    }
 }
 
 impl NfcReader for PCSC {

--- a/src/nfc/pcsc.rs
+++ b/src/nfc/pcsc.rs
@@ -1,0 +1,73 @@
+use {
+    super::{CardType, NfcReader},
+    crate::iso7816::StatusWord,
+    anyhow::{anyhow, bail, ensure, Result},
+    pcsc::*,
+};
+
+pub struct PCSC {
+    ctx:  Context,
+    card: Option<Card>,
+}
+
+impl PCSC {
+    pub fn init() -> Result<Self> {
+        // Establish a PC/SC context
+        let ctx = Context::establish(Scope::User)
+            .map_err(|e| anyhow!("Failed to establish context: {e}"))?;
+        Ok(PCSC {ctx, card: None})
+    }
+
+    pub fn connect(&mut self) -> Result<()> {
+        // List available readers
+        let mut readers_buf = [0; 2048];
+        let mut readers = self.ctx
+            .list_readers(&mut readers_buf)
+            .map_err(|e| anyhow!("Failed to list readers: {e}"))?;
+
+        // Find first reader with card
+        let card = readers
+            .find_map(|reader| self.ctx.connect(reader, ShareMode::Shared, Protocols::ANY).ok())
+            .ok_or_else(|| anyhow!("No card found"))?;
+
+        self.card = Some(card);
+
+        Ok(())
+    }
+
+    pub fn send(&mut self, apdu: &[u8]) -> Result<(StatusWord, Vec<u8>)> {
+        let Some(card) = &self.card else { bail!("Not connected to a card") };
+        let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
+        let rapdu = card
+            .transmit(apdu, &mut rapdu_buf)
+            .map_err(|e| anyhow!("Failed to transmit APDU command to card: {e}"))?;
+        ensure!(rapdu.len() >= 2);
+        let (data, status) = rapdu.split_at(rapdu.len() - 2);
+        let status = u16::from_be_bytes([status[0], status[1]]).into();
+        Ok((status, data.to_vec()))
+    }
+
+    pub fn disconnect(&mut self) -> Result<()> {
+        // pcsc::Card implements drop() with Disposition::ResetCard
+        self.card = None;
+        Ok(())
+    }
+
+    pub fn ctx(&self) -> &Context { &self.ctx }
+    pub fn ctx_mut(&mut self) -> &mut Context { &mut self.ctx }
+}
+
+impl NfcReader for PCSC {
+    fn connect(&mut self) -> Result<Option<CardType>> {
+        self.connect()?;
+        Ok(Some(CardType::Abstract))
+    }
+
+    fn disconnect(&mut self) -> Result<()> {
+        self.disconnect()
+    }
+
+    fn send_apdu(&mut self, apdu: &[u8]) -> Result<(StatusWord, Vec<u8>)> {
+        self.send(apdu)
+    }
+}

--- a/src/nfc/proxmark3/mod.rs
+++ b/src/nfc/proxmark3/mod.rs
@@ -355,7 +355,7 @@ impl NfcReader for Proxmark3 {
         let data = match self.current_card {
             Some(CardType::A(_)) => self.hf14a_send(apdu)?,
             Some(CardType::B(_)) => self.hf14b_send(apdu)?,
-            None => bail!("No card connected"),
+            _ => bail!("No card connected"),
         };
         ensure!(data.len() >= 2);
         let (data, status) = data.split_at(data.len() - 2);

--- a/src/nfc/proxmark3/usb.rs
+++ b/src/nfc/proxmark3/usb.rs
@@ -28,7 +28,7 @@ impl UsbConnection {
                 return Self::from_device(device);
             }
         }
-        panic!("Proxmark3 device not found");
+        Err(anyhow!("Proxmark3 device not found"))
     }
 
     pub fn from_device(device: rusb::Device<GlobalContext>) -> Result<Self> {


### PR DESCRIPTION
Adds basic PCSC support through the `pcsc` crate. Uses the operating system PCSC running daemon to connect to any available card using any available reader.