### PR TITLE
Select eMRTD application before BAC

### DIFF
--- a/src/emrtd/bac.rs
+++ b/src/emrtd/bac.rs
@@ -36,6 +36,9 @@ impl Emrtd {
     }
 
     pub fn basic_access_control(&mut self, rng: &mut impl Rng, mrz: &str) -> Result<()> {
+        // eMRTD application must be selected
+        self.select_emrtd_application()?;
+
         // Compute local randomness
         let rnd_ifd: [u8; 8] = rng.gen();
         let k_ifd: [u8; 16] = rng.gen();

--- a/src/emrtd/files/file_id.rs
+++ b/src/emrtd/files/file_id.rs
@@ -131,7 +131,7 @@ impl FileId {
     }
 
     pub fn file_id(&self) -> u16 {
-        // CardAccess and Sod are the same, but live in different applications.
+        // CardSecurity and Sod are the same, but live in different applications.
         match self {
             Self::AttrInfo => 0x2f01,
             Self::Dir => 0x2f00,

--- a/src/emrtd/files/mod.rs
+++ b/src/emrtd/files/mod.rs
@@ -49,14 +49,15 @@ impl Emrtd {
             return Ok(entry.clone());
         }
 
-        // Select parent file if necessary.
-        if self.parent != file.parent() {
-            if let Some(application_id) = file.parent().aid() {
-                self.select_dedicated_file(application_id)?;
-            } else {
-                self.select_master_file()?;
-            }
-        }
+        // TODO: PACE support required for MF
+        //// Select parent file if necessary.
+        // if self.parent != file.parent() {
+        //    if let Some(application_id) = file.parent().aid() {
+        //        self.select_dedicated_file(application_id)?;
+        //    } else {
+        //        self.select_master_file()?;
+        //    }
+        //}
 
         // Read file by short EF.
         let mut result: Option<Vec<u8>> = match self.read_binary_short_ef(file.short_id()) {
@@ -123,6 +124,11 @@ impl Emrtd {
         ensure_err!(status.is_success(), status.into());
         ensure_err!(data.is_empty(), Error::ResponseDataUnexpected);
         Ok(())
+    }
+
+    pub fn select_emrtd_application(&mut self) -> Result<()> {
+        let id = file_id::EMRTD_LDS1_AID;
+        self.select_dedicated_file(id)
     }
 
     /// Read binary data from an elementary file using a Short EF identifier.


### PR DESCRIPTION
Per ICAO 9303-11 4.2 step 4., the eMRTD application/DF must be selected prior to running BAC. Implemented/required by a Portuguese passport.

This also means that the security context established by BAC (secure messaging) may only work while the eMRTD application is selected. Security contexts maybe application specific, per ISO 7816-4 6.3.3.
Selecting the Master File to read EF.CardAccess, EF.CardSecurity, etc., after a BAC session was established, the error 0x6882 ("secure messaging not supported") is returned on any read attempt.

Better support for Master File reads is then pending on the PACE implementation, which should provide access to both LDS1 eMRTD application files and Master File's files.
