### PR TITLE
APDU builder, commands refactor

### DIFF
--- a/src/emrtd/bac.rs
+++ b/src/emrtd/bac.rs
@@ -10,31 +10,6 @@ use {
 };
 
 impl Emrtd {
-    /// Get random nonce for authentication.
-    ///
-    /// See ICAO 9303-11 section 4.3.4.1.
-    pub fn get_challenge(&mut self) -> Result<Vec<u8>> {
-        let (status, data) = self.send_apdu(&[0x00, 0x84, 0x00, 0x00, 0x08])?;
-        if !status.is_success() {
-            return Err(anyhow!("Failed to get challenge: {}", status));
-        }
-        ensure!(status.data_remaining() == None);
-        ensure!(data.len() == 8);
-        Ok(data)
-    }
-
-    pub fn external_authenticate(&mut self, data: &[u8]) -> Result<Vec<u8>> {
-        assert_eq!(data.len(), 0x28);
-        let mut apdu = vec![0x00, 0x82, 0x00, 0x00, 0x28];
-        apdu.extend_from_slice(data);
-        apdu.push(0x00);
-        let (status, data) = self.send_apdu(&apdu)?;
-        if !status.is_success() {
-            return Err(anyhow!("Failed to authenticate: {}", status));
-        }
-        Ok(data)
-    }
-
     pub fn basic_access_control(&mut self, rng: &mut impl Rng, mrz: &str) -> Result<()> {
         // eMRTD application must be selected
         self.select_emrtd_application()?;
@@ -48,7 +23,7 @@ impl Emrtd {
         let cipher = TDesCipher::from_seed(&seed);
 
         // GET CHALLENGE
-        let rnd_ic = self.get_challenge()?;
+        let rnd_ic = self.commands().get_challenge()?;
 
         // Construct authentication data
         let mut msg = vec![];
@@ -61,7 +36,7 @@ impl Emrtd {
         msg.extend(cipher.mac(0, &msg_mac));
 
         // EXTERNAL AUTHENTICATE
-        let mut resp_data = self.external_authenticate(&msg)?;
+        let mut resp_data = self.commands().external_authenticate(&msg)?;
         ensure!(resp_data.len() == 40);
 
         // Check MAC and decrypt response

--- a/src/emrtd/bac.rs
+++ b/src/emrtd/bac.rs
@@ -4,7 +4,7 @@ use {
         secure_messaging::{tdes::TDesCipher, Cipher, Encrypted},
         seed_from_mrz, Emrtd,
     },
-    anyhow::{anyhow, ensure, Result},
+    anyhow::{ensure, Result},
     rand::Rng,
     std::array,
 };

--- a/src/emrtd/chip_authentication.rs
+++ b/src/emrtd/chip_authentication.rs
@@ -38,7 +38,7 @@ impl Emrtd {
         // For AES we need to use 6.2.4.2
 
         // Send MSE Set AT to select the Chip Authentication protocol.
-        self.mset_at(ca.protocol.into(), pk.key_id)?;
+        self.mset_at_ca(ca.protocol.into(), pk.key_id)?;
 
         // Send the public key using general authenticate
         let data = self.general_authenticate(public_key.as_ref())?;
@@ -51,7 +51,7 @@ impl Emrtd {
         Ok(())
     }
 
-    pub fn mset_at(&mut self, protocol: Oid, key_id: Option<u64>) -> Result<()> {
+    pub fn mset_at_ca(&mut self, protocol: Oid, key_id: Option<u64>) -> Result<()> {
         // Send MSE Set AT to select the Chip Authentication protocol.
         let mut apdu = vec![0x00, 0x22, 0x41, 0xa4];
         apdu.push(0x00); // Placeholder length

--- a/src/emrtd/chip_authentication.rs
+++ b/src/emrtd/chip_authentication.rs
@@ -4,7 +4,7 @@ use {
         asn1::emrtd::{security_info::SymmetricCipher, EfDg14},
         emrtd::secure_messaging::construct_secure_messaging,
     },
-    anyhow::{ensure, Result},
+    anyhow::Result,
     der::asn1::ObjectIdentifier as Oid,
     rand::{CryptoRng, RngCore},
 };
@@ -38,10 +38,12 @@ impl Emrtd {
         // For AES we need to use 6.2.4.2
 
         // Send MSE Set AT to select the Chip Authentication protocol.
-        self.mset_at_ca(ca.protocol.into(), pk.key_id)?;
+        self.mset_at_chip_auth(ca.protocol.into(), pk.key_id)?;
 
         // Send the public key using general authenticate
-        let data = self.general_authenticate(public_key.as_ref())?;
+        let data = self
+            .commands()
+            .general_authenticate(&[(0x80, public_key.as_ref())], true)?;
         println!("==> General Authenticate: {}", hex::encode(data));
 
         // Keys should now have been changed.
@@ -51,46 +53,18 @@ impl Emrtd {
         Ok(())
     }
 
-    pub fn mset_at_ca(&mut self, protocol: Oid, key_id: Option<u64>) -> Result<()> {
+    fn mset_at_chip_auth(&mut self, protocol: Oid, key_id: Option<u64>) -> Result<()> {
         // Send MSE Set AT to select the Chip Authentication protocol.
-        let mut apdu = vec![0x00, 0x22, 0x41, 0xa4];
-        apdu.push(0x00); // Placeholder length
-
-        // Cryptographic mechanism: 0x80 <len> <OID>
-        let protocol = protocol.as_bytes();
-        apdu.push(0x80);
-        apdu.push(protocol.len().try_into()?);
-        apdu.extend_from_slice(protocol);
-
-        // If the pivate key to be used has a reference, include it.
         if let Some(id) = key_id {
-            apdu.push(0x84);
-            apdu.push(0x01); // Assume id < 256
-            apdu.push(id.try_into()?);
+            self.commands().mset_at(0x41a4, &[
+                (0x80, protocol.as_bytes()), // Cryptographic mechanism
+                (0x84, &[id.try_into()?]),   // Key reference
+            ])
+        } else {
+            self.commands().mset_at(
+                0x41a4,
+                &[(0x80, protocol.as_bytes())], // Cryptographic mechanism
+            )
         }
-
-        // Update length
-        apdu[4] = (apdu.len() - 5).try_into()?;
-
-        // Send MSE Set AT command to chip
-        let (status, data) = self.send_apdu(&apdu)?;
-        ensure!(status.is_success());
-        ensure!(data.is_empty());
-        Ok(())
-    }
-
-    pub fn general_authenticate(&mut self, public_key: &[u8]) -> Result<Vec<u8>> {
-        // Send General Authenticate command to chip
-        let mut apdu = vec![0x00, 0x86, 0x00, 0x00];
-        apdu.push((public_key.len() + 4).try_into()?);
-        apdu.push(0x7c);
-        apdu.push((public_key.len() + 2).try_into()?);
-        apdu.push(0x80);
-        apdu.push(public_key.len().try_into()?);
-        apdu.extend_from_slice(public_key);
-
-        let (status, data) = self.send_apdu(&apdu)?;
-        ensure!(status.is_success());
-        Ok(data)
     }
 }

--- a/src/emrtd/chip_authentication.rs
+++ b/src/emrtd/chip_authentication.rs
@@ -44,7 +44,7 @@ impl Emrtd {
         let data = self
             .commands()
             .general_authenticate(&[(0x80, public_key.as_ref())], true)?;
-        println!("==> General Authenticate: {}", hex::encode(data));
+        println!("==> General Authenticate OK");
 
         // Keys should now have been changed.
         let cipher = SymmetricCipher::Aes256;

--- a/src/emrtd/commands.rs
+++ b/src/emrtd/commands.rs
@@ -26,6 +26,17 @@ impl<'a> Commands<'a> {
         Ok(data)
     }
 
+    /// Send INTERNAL AUTHENTICATE command.
+    pub fn internal_authenticate(&mut self, data: &[u8]) -> Result<Vec<u8>> {
+        let apdu = Apdu::new(0x00, 0x88, 0x00, 0x00, None)
+            .push_bytes(data)
+            .build()?;
+
+        let (status, data) = self.card.send_apdu(&apdu)?;
+        ensure!(status.is_success(), "Failed to authenticate: {}", status);
+        Ok(data)
+    }
+
     /// Send EXTERNAL AUTHENTICATE command.
     pub fn external_authenticate(&mut self, data: &[u8]) -> Result<Vec<u8>> {
         ensure!(data.len() == 0x28);

--- a/src/emrtd/commands.rs
+++ b/src/emrtd/commands.rs
@@ -1,6 +1,7 @@
 use {
     super::{iso7816::Apdu, Emrtd},
     anyhow::{ensure, Result},
+    bytes::Buf,
 };
 
 pub struct Commands<'a> {
@@ -64,7 +65,11 @@ impl<'a> Commands<'a> {
 
     /// Send GENERAL AUTHENTICATE command. Uses command chaining.
     /// Set `last` to false if more APDUs to be sent.
-    pub fn general_authenticate(&mut self, data: &[(u8, &[u8])], last: bool) -> Result<Vec<u8>> {
+    pub fn general_authenticate(
+        &mut self,
+        data: &[(u8, &[u8])],
+        last: bool,
+    ) -> Result<Vec<(u8, Vec<u8>)>> {
         let mut apdu = Apdu::new(0x00, 0x86, 0x00, 0x00, None);
         apdu.dynamic_auth();
         if !last {
@@ -77,6 +82,37 @@ impl<'a> Commands<'a> {
         let (status, data) = self.card.send_apdu(&apdu.build()?)?;
         ensure!(status.is_success(), "Failed to authenticate: {}", status);
 
-        Ok(data)
+        let mut buf = &data[..];
+        ensure!(buf.has_remaining(), "Empty response");
+        ensure!(
+            buf.get_u8() == 0x7c,
+            "Invalid Dynamic Authentication response tag"
+        );
+
+        let outer_len = buf.get_u8();
+
+        // Check if we have an empty response (just 0x7C 00)
+        if outer_len == 0 {
+            return Ok(Vec::new());
+        }
+
+        ensure!(
+            buf.remaining() >= outer_len as usize,
+            "Invalid outer length"
+        );
+
+        let mut result = Vec::new();
+        while buf.has_remaining() {
+            ensure!(buf.remaining() >= 2, "Truncated TLV");
+            let tag = buf.get_u8();
+            let len = buf.get_u8();
+
+            ensure!(buf.remaining() >= len as usize, "Invalid TLV length");
+            let value = buf.copy_to_bytes(len as usize).to_vec();
+
+            result.push((tag, value));
+        }
+
+        Ok(result)
     }
 }

--- a/src/emrtd/commands.rs
+++ b/src/emrtd/commands.rs
@@ -1,6 +1,6 @@
 use {
-    super::Emrtd,
-    anyhow::{anyhow, ensure, Result},
+    super::{iso7816::Apdu, Emrtd},
+    anyhow::{ensure, Result},
 };
 
 pub struct Commands<'a> {
@@ -17,10 +17,10 @@ impl<'a> Commands<'a> {
     ///
     /// See ICAO 9303-11 section 4.3.4.1.
     pub fn get_challenge(&mut self) -> Result<Vec<u8>> {
-        let (status, data) = self.card.send_apdu(&[0x00, 0x84, 0x00, 0x00, 0x08])?;
-        if !status.is_success() {
-            return Err(anyhow!("Failed to get challenge: {}", status));
-        }
+        let apdu = Apdu::new(0x00, 0x84, 0x00, 0x00, Some(8)).build()?;
+
+        let (status, data) = self.card.send_apdu(&apdu)?;
+        ensure!(status.is_success(), "Failed to get challenge: {}", status);
         ensure!(status.data_remaining() == None);
         ensure!(data.len() == 8);
         Ok(data)
@@ -28,46 +28,43 @@ impl<'a> Commands<'a> {
 
     /// Send EXTERNAL AUTHENTICATE command.
     pub fn external_authenticate(&mut self, data: &[u8]) -> Result<Vec<u8>> {
-        assert_eq!(data.len(), 0x28);
-        let mut apdu = vec![0x00, 0x82, 0x00, 0x00, 0x28];
-        apdu.extend_from_slice(data);
-        apdu.push(0x00);
+        ensure!(data.len() == 0x28);
+        let apdu = Apdu::new(0x00, 0x82, 0x00, 0x00, None)
+            .push_bytes(data)
+            .build()?;
+
         let (status, data) = self.card.send_apdu(&apdu)?;
-        if !status.is_success() {
-            return Err(anyhow!("Failed to authenticate: {}", status));
-        }
+        ensure!(status.is_success(), "Failed to authenticate: {}", status);
         Ok(data)
     }
 
     /// Send MSE:Set AT command.
-    pub fn mset_at(&mut self, at: u16, data: &[u8]) -> Result<()> {
-        let mut apdu = vec![0x00, 0x22];
-        let p1p2 = &[(at >> 8) as u8, at as u8];
-        apdu.extend_from_slice(p1p2);
-        apdu.push(data.len().try_into()?);
-        apdu.extend_from_slice(data);
+    pub fn mset_at(&mut self, at: u16, data: &[(u8, &[u8])]) -> Result<()> {
+        let mut apdu = Apdu::new(0x00, 0x22, (at >> 8) as u8, at as u8, Some(0));
+        for (tag, bytes) in data {
+            apdu.push_tlv(*tag, bytes)?;
+        }
 
-        let (status, data) = self.card.send_apdu(&data)?;
+        let (status, data) = self.card.send_apdu(&apdu.build()?)?;
         ensure!(status.is_success());
         ensure!(data.is_empty());
         Ok(())
     }
 
-    pub fn general_authenticate(&mut self, data: &[u8], last: bool) -> Result<Vec<u8>> {
-        let mut apdu = vec![0x00, 0x86, 0x00, 0x00];
+    /// Send GENERAL AUTHENTICATE command. Uses command chaining.
+    /// Set `last` to false if more APDUs to be sent.
+    pub fn general_authenticate(&mut self, data: &[(u8, &[u8])], last: bool) -> Result<Vec<u8>> {
+        let mut apdu = Apdu::new(0x00, 0x86, 0x00, 0x00, None);
+        apdu.dynamic_auth();
         if !last {
-            apdu[0] |= 0x10;
-        };
-        apdu.push(2 + u8::try_from(data.len())?);
-        apdu.push(0x7c); // Dynamic authentication
-        apdu.push(data.len().try_into()?);
-        apdu.extend_from_slice(data);
-        apdu.push(0x00); // Allow response length up to 256 bytes
-
-        let (status, data) = self.card.send_apdu(&apdu)?;
-        if !status.is_success() {
-            return Err(anyhow!("Failed to authenticate: {}", status));
+            apdu.chain();
         }
+        for (tag, bytes) in data {
+            apdu.push_tlv(*tag, bytes)?;
+        }
+
+        let (status, data) = self.card.send_apdu(&apdu.build()?)?;
+        ensure!(status.is_success(), "Failed to authenticate: {}", status);
 
         Ok(data)
     }

--- a/src/emrtd/commands.rs
+++ b/src/emrtd/commands.rs
@@ -1,0 +1,74 @@
+use {
+    super::Emrtd,
+    anyhow::{anyhow, ensure, Result},
+};
+
+pub struct Commands<'a> {
+    card: &'a mut Emrtd,
+}
+
+impl<'a> Commands<'a> {
+    pub fn new(card: &'a mut Emrtd) -> Self {
+        Self { card }
+    }
+
+    /// Send GET CHALLENGE command.
+    /// Gets random nonce for authentication.
+    ///
+    /// See ICAO 9303-11 section 4.3.4.1.
+    pub fn get_challenge(&mut self) -> Result<Vec<u8>> {
+        let (status, data) = self.card.send_apdu(&[0x00, 0x84, 0x00, 0x00, 0x08])?;
+        if !status.is_success() {
+            return Err(anyhow!("Failed to get challenge: {}", status));
+        }
+        ensure!(status.data_remaining() == None);
+        ensure!(data.len() == 8);
+        Ok(data)
+    }
+
+    /// Send EXTERNAL AUTHENTICATE command.
+    pub fn external_authenticate(&mut self, data: &[u8]) -> Result<Vec<u8>> {
+        assert_eq!(data.len(), 0x28);
+        let mut apdu = vec![0x00, 0x82, 0x00, 0x00, 0x28];
+        apdu.extend_from_slice(data);
+        apdu.push(0x00);
+        let (status, data) = self.card.send_apdu(&apdu)?;
+        if !status.is_success() {
+            return Err(anyhow!("Failed to authenticate: {}", status));
+        }
+        Ok(data)
+    }
+
+    /// Send MSE:Set AT command.
+    pub fn mset_at(&mut self, at: u16, data: &[u8]) -> Result<()> {
+        let mut apdu = vec![0x00, 0x22];
+        let p1p2 = &[(at >> 8) as u8, at as u8];
+        apdu.extend_from_slice(p1p2);
+        apdu.push(data.len().try_into()?);
+        apdu.extend_from_slice(data);
+
+        let (status, data) = self.card.send_apdu(&data)?;
+        ensure!(status.is_success());
+        ensure!(data.is_empty());
+        Ok(())
+    }
+
+    pub fn general_authenticate(&mut self, data: &[u8], last: bool) -> Result<Vec<u8>> {
+        let mut apdu = vec![0x00, 0x86, 0x00, 0x00];
+        if !last {
+            apdu[0] |= 0x10;
+        };
+        apdu.push(2 + u8::try_from(data.len())?);
+        apdu.push(0x7c); // Dynamic authentication
+        apdu.push(data.len().try_into()?);
+        apdu.extend_from_slice(data);
+        apdu.push(0x00); // Allow response length up to 256 bytes
+
+        let (status, data) = self.card.send_apdu(&apdu)?;
+        if !status.is_success() {
+            return Err(anyhow!("Failed to authenticate: {}", status));
+        }
+
+        Ok(data)
+    }
+}

--- a/src/emrtd/mod.rs
+++ b/src/emrtd/mod.rs
@@ -2,13 +2,17 @@
 
 mod bac;
 mod chip_authentication;
+mod commands;
 mod files;
 mod pace;
 pub mod secure_messaging;
 
 pub use self::files::{DedicatedId, FileId, HasFileId};
 use {
-    self::secure_messaging::{PlainText, SecureMessaging},
+    self::{
+        commands::Commands,
+        secure_messaging::{PlainText, SecureMessaging},
+    },
     crate::{
         iso7816::{self, StatusWord},
         nfc::NfcReader,
@@ -97,6 +101,11 @@ impl Emrtd {
 
     pub fn set_secure_messaging(&mut self, secure_messaging: Box<dyn SecureMessaging>) {
         self.secure_messaging = secure_messaging;
+    }
+
+    /// Commands dispatcher
+    pub fn commands(&mut self) -> Commands {
+        Commands::new(self)
     }
 
     pub fn send_apdu(&mut self, apdu: &[u8]) -> Result<(StatusWord, Vec<u8>)> {

--- a/src/iso7816/mod.rs
+++ b/src/iso7816/mod.rs
@@ -1,10 +1,7 @@
 mod status_word;
 
 pub use self::status_word::StatusWord;
-use {
-    anyhow::{anyhow, Result},
-    thiserror::Error,
-};
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -22,6 +19,9 @@ pub enum Error {
 
     #[error("Invalid Extended APDU: Trailing bytes.")]
     ExtendedApduTooLong,
+
+    #[error("Failed building APDU: {0}")]
+    BuildFailure(#[from] anyhow::Error),
 }
 
 // TODO handle extended lengths
@@ -29,28 +29,38 @@ pub enum Error {
 pub struct Apdu {
     header:       [u8; 4],
     data:         Vec<u8>,
+    rlen:         Option<u8>,
     dynamic_auth: bool,
 }
 
 impl Apdu {
-    pub fn new(cla: u8, ins: u8, p1: u8, p2: u8) -> Self {
+    /// Creates an empty APDU, with an expected response length `rlen`.
+    /// If `rlen` is `None`, then a response of 256 bytes is assumed.
+    pub fn new(cla: u8, ins: u8, p1: u8, p2: u8, rlen: Option<u8>) -> Self {
         let header = [cla, ins, p1, p2];
         // Lets assume a short APDU by default
         let data = Vec::with_capacity(255);
         Self {
             header,
             data,
+            rlen,
             dynamic_auth: false,
         }
     }
 
-    /// Pushes bytes into the APDU data field. Constructs the TLV sequence.
-    pub fn push(&mut self, tag: u8, data: &[u8]) -> Result<&mut Self> {
+    /// Pushes bytes into the APDU data field. Constructs a TLV sequence.
+    pub fn push_tlv(&mut self, tag: u8, data: &[u8]) -> anyhow::Result<&mut Self> {
         let len = u8::try_from(data.len())?;
         self.data.push(tag);
         self.data.push(len);
         self.data.extend_from_slice(data);
         Ok(self)
+    }
+
+    /// Pushes raw bytes into the APDU data field.
+    pub fn push_bytes(&mut self, data: &[u8]) -> &mut Self {
+        self.data.extend_from_slice(data);
+        self
     }
 
     pub fn dynamic_auth(&mut self) -> &mut Self {
@@ -65,15 +75,13 @@ impl Apdu {
         self
     }
 
-    /// Builds the APDU, with an expected response length `rlen`.
-    /// If `rlen` is `None`, then a response of 256 bytes is assumed.
-    pub fn build(&self, rlen: Option<u8>) -> Result<Vec<u8>> {
+    pub fn build(&self) -> anyhow::Result<Vec<u8>> {
         // le == 0x00 equates to a 256 bytes response
         let dyn_auth_len: u8 = if self.dynamic_auth { 2 } else { 0 };
         let data_len = u8::try_from(self.data.len())?;
-        let le_present = rlen.is_some_and(|len| len != 0) || rlen.is_none();
+        let le_present = self.rlen.is_some_and(|len| len != 0) || self.rlen.is_none();
         let len = 4 // header
-            + 1 // lc
+            + (dyn_auth_len + data_len != 0) as usize  // lc
             + dyn_auth_len as usize
             + data_len as usize
             + le_present as usize;
@@ -82,11 +90,9 @@ impl Apdu {
         // header
         apdu.extend_from_slice(&self.header);
         // lc
-        apdu.push(
-            dyn_auth_len
-                .checked_add(data_len)
-                .ok_or_else(|| anyhow!("Dynamic authentication object too large"))?,
-        );
+        if dyn_auth_len + data_len != 0 {
+            apdu.push((dyn_auth_len + data_len).try_into()?);
+        }
         // data
         if self.dynamic_auth {
             apdu.push(0x7c);
@@ -97,7 +103,7 @@ impl Apdu {
         }
         // le
         if le_present {
-            apdu.push(rlen.unwrap_or(0));
+            apdu.push(self.rlen.unwrap_or(0));
         }
 
         Ok(apdu)

--- a/src/iso7816/mod.rs
+++ b/src/iso7816/mod.rs
@@ -1,7 +1,10 @@
 mod status_word;
 
 pub use self::status_word::StatusWord;
-use thiserror::Error;
+use {
+    anyhow::{anyhow, Result},
+    thiserror::Error,
+};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -19,6 +22,86 @@ pub enum Error {
 
     #[error("Invalid Extended APDU: Trailing bytes.")]
     ExtendedApduTooLong,
+}
+
+// TODO handle extended lengths
+#[derive(Debug, Clone)]
+pub struct Apdu {
+    header:       [u8; 4],
+    data:         Vec<u8>,
+    dynamic_auth: bool,
+}
+
+impl Apdu {
+    pub fn new(cla: u8, ins: u8, p1: u8, p2: u8) -> Self {
+        let header = [cla, ins, p1, p2];
+        // Lets assume a short APDU by default
+        let data = Vec::with_capacity(255);
+        Self {
+            header,
+            data,
+            dynamic_auth: false,
+        }
+    }
+
+    /// Pushes bytes into the APDU data field. Constructs the TLV sequence.
+    pub fn push(&mut self, tag: u8, data: &[u8]) -> Result<&mut Self> {
+        let len = u8::try_from(data.len())?;
+        self.data.push(tag);
+        self.data.push(len);
+        self.data.extend_from_slice(data);
+        Ok(self)
+    }
+
+    pub fn dynamic_auth(&mut self) -> &mut Self {
+        self.dynamic_auth = true;
+        self
+    }
+
+    /// Command chaining. Must be called if this is not the last APDU in the
+    /// chain.
+    pub fn chain(&mut self) -> &mut Self {
+        self.header[0] |= 0x10;
+        self
+    }
+
+    /// Builds the APDU, with an expected response length `rlen`.
+    /// If `rlen` is `None`, then a response of 256 bytes is assumed.
+    pub fn build(&self, rlen: Option<u8>) -> Result<Vec<u8>> {
+        // le == 0x00 equates to a 256 bytes response
+        let dyn_auth_len: u8 = if self.dynamic_auth { 2 } else { 0 };
+        let data_len = u8::try_from(self.data.len())?;
+        let le_present = rlen.is_some_and(|len| len != 0) || rlen.is_none();
+        let len = 4 // header
+            + 1 // lc
+            + dyn_auth_len as usize
+            + data_len as usize
+            + le_present as usize;
+
+        let mut apdu = Vec::with_capacity(len);
+        // header
+        apdu.extend_from_slice(&self.header);
+        // lc
+        apdu.push(
+            dyn_auth_len
+                .checked_add(data_len)
+                .ok_or_else(|| anyhow!("Dynamic authentication object too large"))?,
+        );
+        // data
+        if self.dynamic_auth {
+            apdu.push(0x7c);
+            apdu.push(data_len);
+        }
+        if self.data.len() > 0 {
+            apdu.extend_from_slice(&self.data);
+        }
+        // le
+        if le_present {
+            apdu.push(rlen.unwrap_or(0));
+        }
+
+        Ok(apdu)
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Adds a helper to build APDUs.
And, refactors `Emrtd` commands a bit using a temp `Commands` struct dispatcher.