### PR TITLE
`KeyAgreementAlgorithm` implementations

### DIFF
--- a/src/asn1/public_key_info/mod.rs
+++ b/src/asn1/public_key_info/mod.rs
@@ -14,8 +14,9 @@ use {
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum SubjectPublicKeyInfo {
-    RSA(RsaPublicKeyInfo),
+    DH((DhAlgoParameters, DhPublicKeyInfo)),
     EC((ECAlgoParameters, EcPublicKeyInfo)),
+    RSA(RsaPublicKeyInfo),
     Unknown(AnySubjectPublicKeyInfo),
 }
 
@@ -34,6 +35,11 @@ pub struct RsaPublicKeyInfo {
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Sequence, ValueOrd)]
 pub struct EcPublicKeyInfo {
     pub point: ECPoint,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Sequence, ValueOrd)]
+pub struct DhPublicKeyInfo {
+    pub key: Int,
 }
 
 /// Diffie-Hellman Mod-P Group Parameters.
@@ -84,6 +90,7 @@ impl SubjectPublicKeyInfo {
     pub fn bit_len(&self) -> usize {
         match self {
             Self::RSA(_info) => todo!(),
+            Self::DH(_info) => todo!(),
             Self::EC((_params, _info)) => todo!(),
             Self::Unknown(info) => info.subject_public_key.bit_len(),
         }
@@ -105,6 +112,7 @@ impl EncodeValue for SubjectPublicKeyInfo {
     fn value_len(&self) -> Result<Length> {
         match self {
             Self::RSA(_info) => todo!(),
+            Self::DH(_info) => todo!(),
             Self::EC((params, info)) => {
                 let algo = PubkeyAlgorithmIdentifier::Ec(params.clone());
                 let key_bits = BitString::new(0, info.point.as_bytes())?;
@@ -117,6 +125,7 @@ impl EncodeValue for SubjectPublicKeyInfo {
     fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         match self {
             Self::RSA(_info) => todo!(),
+            Self::DH(_info) => todo!(),
             Self::EC((params, info)) => {
                 PubkeyAlgorithmIdentifier::Ec(params.clone()).encode(writer)?;
                 BitString::new(0, info.point.as_bytes())?.encode(writer)

--- a/src/bin/test-dg14.rs
+++ b/src/bin/test-dg14.rs
@@ -37,14 +37,17 @@ fn main() -> Result<()> {
 
             // Construct elliptic curve and document public key point.
             let (algo, doc_public_key) = capk.public_key.to_algorithm_public_key()?;
-            println!("   - Algorithm: {algo}");
-            println!("   - Card Public Key: {}", hex::encode(&doc_public_key));
+            println!("   - Algorithm: {algo:?}");
+            println!(
+                "   - Card Public Key: {}",
+                hex::encode(doc_public_key.to_bytes())
+            );
 
             // Generate keypair
             let mut rng = rand::thread_rng();
             let (private_key, public_key) = algo.generate_key_pair(&mut rng);
             // println!("   - Private key: {:x}", private_key);
-            println!("   - Public key: {}", hex::encode(&public_key));
+            println!("   - Public key: {}", hex::encode(public_key.to_bytes()));
 
             // Compute shared secret
             let shared_secret = algo.key_agreement(&private_key, &doc_public_key)?;

--- a/src/bin/tester.rs
+++ b/src/bin/tester.rs
@@ -159,13 +159,16 @@ fn main() -> Result<()> {
 
                 // Construct elliptic curve and document public key point.
                 let (algo, doc_public_key) = capk.public_key.to_algorithm_public_key()?;
-                println!("   - Aglo: {}", algo);
-                println!("   - Card Public Key: {}", hex::encode(&doc_public_key));
+                println!("   - Aglo: {:?}", algo);
+                println!(
+                    "   - Card Public Key: {}",
+                    hex::encode(doc_public_key.to_bytes())
+                );
 
                 // Generate keypair
                 let mut rng = rand::thread_rng();
                 let (private_key, public_key) = algo.generate_key_pair(&mut rng);
-                println!("   - Public key: {}", hex::encode(public_key));
+                println!("   - Public key: {}", hex::encode(public_key.to_bytes()));
 
                 // Compute shared secret
                 let shared_secret = algo.key_agreement(&private_key, &doc_public_key)?;

--- a/src/crypto/codec/bsi_tr03111.rs
+++ b/src/crypto/codec/bsi_tr03111.rs
@@ -3,9 +3,9 @@ use {
     super::Codec,
     crate::crypto::{
         groups::{EllipticCurve, EllipticCurvePoint},
-        mod_ring::{ModRingElement, RingRef, RingRefExt},
+        mod_ring::{ModRingElement, RingRef, RingRefExt, UintMont},
     },
-    anyhow::{anyhow, ensure, Result},
+    anyhow::{anyhow, bail, ensure, Result},
     bytes::{Buf, BufMut},
     ruint::Uint,
 };
@@ -129,6 +129,39 @@ impl<'a, const BITS: usize, const LIMBS: usize> Codec<EllipticCurvePoint<'a, Uin
             _ => Err(anyhow!("Invalid byte for elliptic curve point")),
         }
     }
+}
+
+/// Parse EC point over `UintMont`
+pub fn parse_ec_point<'a, U: UintMont>(curve: &'a EllipticCurve<U>, os: &[u8]) -> Result<(U, U)> {
+    let coords = &os[1..];
+    match os[0] {
+        0 => bail!("Infinity point"),
+        2 | 3 => {
+            let x = U::from_be_bytes(coords);
+            let x_elem = curve.base_field().from(x);
+            let p = curve
+                .from_x(x_elem)
+                .ok_or_else(|| anyhow!("Invalid x coordinate"))?;
+            let y = p
+                .y()
+                .ok_or_else(|| anyhow!("Failed deriving EC point y"))?
+                .to_uint();
+            Ok((x, y))
+        }
+        4 => parse_ec_point_uncompressed(coords),
+        _ => bail!("Invalid byte for elliptic curve point"),
+    }
+}
+
+/// Parse EC point over `UintMont`, uncompressed
+pub fn parse_ec_point_uncompressed<'a, U: UintMont>(os: &[u8]) -> Result<(U, U)> {
+    ensure!(os[0] == 4, "Unhandled compressed point");
+    let coords = &os[1..];
+    let (x_bytes, y_bytes) = coords.split_at(coords.len() / 2);
+
+    let x = U::from_be_bytes(x_bytes);
+    let y = U::from_be_bytes(y_bytes);
+    Ok((x, y))
 }
 
 #[cfg(test)]

--- a/src/crypto/codec/mod.rs
+++ b/src/crypto/codec/mod.rs
@@ -3,7 +3,7 @@ mod buf;
 mod icao_9303;
 
 pub use self::{
-    bsi_tr03111::BsiTr031111Codec,
+    bsi_tr03111::{parse_ec_point, parse_ec_point_uncompressed, BsiTr031111Codec},
     buf::{BufCodec, BufCodecParent, BufMutCodec},
 };
 use {

--- a/src/crypto/dh.rs
+++ b/src/crypto/dh.rs
@@ -1,0 +1,7 @@
+use super::{groups::ModPGroup, mod_ring::UintMont};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DHPublicKey<U: UintMont, V: UintMont> {
+    pub group: ModPGroup<U, V>,
+    pub key:   U,
+}

--- a/src/crypto/ecdsa.rs
+++ b/src/crypto/ecdsa.rs
@@ -2,16 +2,16 @@
 
 use {
     super::{
+        codec::parse_ec_point,
         groups::{EllipticCurve, EllipticCurvePoint},
         mod_ring::{ModRingElementRef, RingRefExt, UintMont},
     },
     crate::asn1::{
-        public_key_info::{ECAlgoParameters, EcPublicKeyInfo, FieldId},
+        public_key_info::{ECAlgoParameters, EcPublicKeyInfo},
         DigestAlgorithmIdentifier, DigestAlgorithmParameters, SignatureAlgorithmIdentifier,
     },
     anyhow::{anyhow, bail, ensure, Result},
     num_traits::Inv,
-    ruint::{aliases::U512, Uint},
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -87,36 +87,15 @@ impl<U: UintMont> ECPublicKey<U> {
     }
 }
 
-impl<const B: usize, const L: usize> TryFrom<(ECAlgoParameters, EcPublicKeyInfo)>
-    for ECPublicKey<Uint<B, L>>
-{
+impl<U: UintMont> TryFrom<(ECAlgoParameters, EcPublicKeyInfo)> for ECPublicKey<U> {
     type Error = anyhow::Error;
 
     fn try_from(info: (ECAlgoParameters, EcPublicKeyInfo)) -> Result<Self> {
         let (params, key) = info;
         let point_bytes = key.point.as_bytes();
-        let curve = match params {
-            ECAlgoParameters::EcParameters(params) => match params.field_id {
-                FieldId::PrimeField { modulus } => {
-                    let p = Uint::try_from(modulus)?;
-                    let a = Uint::from_be_slice(params.curve.a.as_bytes());
-                    let b = Uint::from_be_slice(params.curve.b.as_bytes());
-                    let (x, y) = parse_ec_point(params.base.as_bytes())?;
-                    let order = Uint::try_from(params.order)?;
-                    let cofactor = Uint::try_from(
-                        params
-                            .cofactor
-                            .ok_or_else(|| anyhow!("Missing cofactor in EcParameters"))?,
-                    )?;
+        let curve = EllipticCurve::from_parameters(params)?;
 
-                    EllipticCurve::new(p, a, b, x, y, order, cofactor)?
-                }
-                _ => todo!(),
-            },
-            _ => todo!(),
-        };
-
-        let (x, y) = parse_ec_point(point_bytes)?;
+        let (x, y) = parse_ec_point(&curve, point_bytes)?;
         Ok(Self {
             curve,
             point: (x, y),
@@ -124,21 +103,13 @@ impl<const B: usize, const L: usize> TryFrom<(ECAlgoParameters, EcPublicKeyInfo)
     }
 }
 
-fn parse_ec_point<const B: usize, const L: usize>(
-    octet_string: &[u8],
-) -> Result<(Uint<B, L>, Uint<B, L>)> {
-    ensure!(
-        octet_string[0] == 0x04,
-        "Only uncompressed EC point supported, TODO others"
-    );
-
-    let coords = &octet_string[1..];
-    let (x_bytes, y_bytes) = coords.split_at(coords.len() / 2);
-
-    let x = Uint::from_be_slice(x_bytes);
-    let y = Uint::from_be_slice(y_bytes);
-
-    Ok((x, y))
+impl<'a, U: UintMont> From<EllipticCurvePoint<'a, U>> for ECPublicKey<U> {
+    fn from(point: EllipticCurvePoint<U>) -> Self {
+        ECPublicKey {
+            curve: point.curve().clone(),
+            point: (point.x().unwrap().to_uint(), point.y().unwrap().to_uint()),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/crypto/groups/elliptic_curve.rs
+++ b/src/crypto/groups/elliptic_curve.rs
@@ -1,9 +1,13 @@
 use {
     super::{
-        super::mod_ring::{ModRing, ModRingElementRef, RingRefExt, UintExp, UintMont},
+        super::{
+            codec::parse_ec_point_uncompressed,
+            mod_ring::{ModRing, ModRingElementRef, RingRefExt, UintExp, UintMont},
+        },
         CryptoGroup,
     },
-    anyhow::{ensure, Result},
+    crate::asn1::public_key_info::{ECAlgoParameters, FieldId},
+    anyhow::{anyhow, ensure, Result},
     num_traits::Inv,
     std::{
         fmt::{self, Debug, Formatter},
@@ -88,6 +92,33 @@ impl<U: UintMont> EllipticCurve<U> {
             "Generator order mismatch"
         );
 
+        Ok(curve)
+    }
+
+    pub fn from_parameters(params: ECAlgoParameters) -> Result<Self> {
+        let curve = match params {
+            ECAlgoParameters::EcParameters(params) => match params.field_id {
+                FieldId::PrimeField { modulus } => {
+                    let p = U::try_from(modulus)
+                        .map_err(|_| anyhow!("Failed converting modulus Int"))?;
+                    let a = U::from_be_bytes(params.curve.a.as_bytes());
+                    let b = U::from_be_bytes(params.curve.b.as_bytes());
+                    let (x, y) = parse_ec_point_uncompressed(params.base.as_bytes())?;
+                    let order = U::try_from(params.order)
+                        .map_err(|_| anyhow!("Failed converting order Int"))?;
+                    let cofactor = U::try_from(
+                        params
+                            .cofactor
+                            .ok_or_else(|| anyhow!("Missing cofactor in EcParameters"))?,
+                    )
+                    .map_err(|_| anyhow!("Failed converting cofactor Int"))?;
+
+                    EllipticCurve::new(p, a, b, x, y, order, cofactor)?
+                }
+                _ => todo!(),
+            },
+            _ => todo!(),
+        };
         Ok(curve)
     }
 
@@ -229,7 +260,7 @@ impl<'a, U: UintMont> EllipticCurvePoint<'a, U> {
         }
     }
 
-    fn mul_uint<W: UintExp>(mut self, scalar: W) -> Self {
+    pub fn mul_uint<W: UintExp>(mut self, scalar: W) -> Self {
         let mut result = self.curve.infinity();
         for i in 0..scalar.bit_len() {
             result.conditional_assign(&(result + self), scalar.bit_ct(i));

--- a/src/crypto/groups/mod.rs
+++ b/src/crypto/groups/mod.rs
@@ -5,7 +5,10 @@ mod modp_group;
 mod mul_group;
 pub mod named;
 
-pub use self::elliptic_curve::{EllipticCurve, EllipticCurvePoint};
+pub use self::{
+    elliptic_curve::{EllipticCurve, EllipticCurvePoint},
+    modp_group::ModPGroup,
+};
 use {
     super::CryptoCoreRng,
     num_traits::Inv,

--- a/src/crypto/groups/modp_group.rs
+++ b/src/crypto/groups/modp_group.rs
@@ -9,7 +9,7 @@ use {
     anyhow::{ensure, Result},
 };
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ModPGroup<U: UintMont, V: UintMont> {
     base_field:      ModRing<U>,
     scalar_field:    ModRing<V>,

--- a/src/crypto/key_agreement.rs
+++ b/src/crypto/key_agreement.rs
@@ -1,0 +1,105 @@
+use {
+    super::{
+        codec::BsiTr031111Codec,
+        dh::DHPublicKey,
+        ecdsa::ECPublicKey,
+        groups::{EllipticCurve, EllipticCurvePoint, ModPGroup},
+        mod_ring::{ModRingElementRef, RingRefExt},
+        Codec, CryptoCoreRng, PrivateKey, PublicKey,
+    },
+    anyhow::{anyhow, bail, ensure, Result},
+    num_traits::Inv,
+    ruint::aliases::U4096,
+    std::fmt::Debug,
+};
+
+type U521 = ruint::Uint<521, 9>;
+
+/// Object safe trait for key agreement algorithms
+pub trait KeyAgreementAlgorithm: Debug {
+    fn generate_key_pair(&self, rng: &mut dyn CryptoCoreRng) -> (PrivateKey, PublicKey);
+    fn key_agreement(&self, private: &PrivateKey, public: &PublicKey) -> Result<Vec<u8>>;
+}
+
+pub trait DiffieHellman {
+    fn generate_private_key(&self, rng: &mut dyn CryptoCoreRng) -> Vec<u8>;
+    fn private_to_public(&self, private: &[u8]) -> Result<Vec<u8>>;
+    fn shared_secret(&self, private: &[u8], public: &[u8]) -> Result<Vec<u8>>;
+}
+
+impl KeyAgreementAlgorithm for ModPGroup<U4096, U4096> {
+    fn generate_key_pair(&self, rng: &mut dyn CryptoCoreRng) -> (PrivateKey, PublicKey) {
+        let private = self.base_field().random(rng).to_uint();
+        let public = self.generator().pow_ct(private);
+        let public = PublicKey::DH(DHPublicKey {
+            group: self.clone(),
+            key:   public.to_uint(),
+        });
+        (PrivateKey(Box::new(private)), public)
+    }
+
+    fn key_agreement(&self, private: &PrivateKey, public: &PublicKey) -> Result<Vec<u8>> {
+        let private: &U4096 = private
+            .0
+            .as_ref()
+            .downcast_ref()
+            .ok_or(anyhow!("Invalid private key"))?;
+        let public = if let PublicKey::DH(key) = public {
+            key
+        } else {
+            bail!("Provided public key is not EC")
+        };
+        let key = public.group.base_field().from(public.key);
+        let shared = key.pow_ct(*private);
+        let mut buf = Vec::new();
+        BsiTr031111Codec::default().encode(&mut buf, shared);
+        Ok(buf)
+    }
+}
+
+impl KeyAgreementAlgorithm for EllipticCurve<U521> {
+    fn generate_key_pair(&self, rng: &mut dyn super::CryptoCoreRng) -> (PrivateKey, PublicKey) {
+        let private = self.scalar_field().random(rng);
+        let public = self.generator() * private;
+        (
+            PrivateKey(Box::new(private.as_montgomery())),
+            PublicKey::EC(public.into()),
+        )
+    }
+
+    fn key_agreement(&self, private: &PrivateKey, public: &PublicKey) -> Result<Vec<u8>> {
+        let private = self.scalar_field().from_montgomery(
+            *private
+                .0
+                .as_ref()
+                .downcast_ref::<U521>()
+                .ok_or(anyhow!("Invalid private key"))?,
+        );
+        let public = if let PublicKey::EC(key) = public {
+            key
+        } else {
+            bail!("Provided public key is not EC")
+        };
+        let (_, shared) = ecka(private, public)?;
+        Ok(shared)
+    }
+}
+
+/// Elliptic Curve Key Agreement
+/// See TR-03111 section 4.3.1
+pub fn ecka<'a>(
+    private_key: ModRingElementRef<'a, U521>,
+    public_key: &'a ECPublicKey<U521>,
+) -> Result<(EllipticCurvePoint<'a, U521>, Vec<u8>)> {
+    let curve = &public_key.curve;
+    let point = public_key.point()?;
+    ensure!(private_key.ring() == curve.scalar_field());
+    let h = curve.cofactor();
+    let l = curve.scalar_field().from(h).inv().unwrap();
+    let q = point.mul_uint(h);
+    let s_ab = q * (private_key * l);
+    ensure!(s_ab != curve.infinity());
+    let mut buf = Vec::new();
+    BsiTr031111Codec::default().encode(&mut buf, s_ab.x().unwrap());
+    Ok((s_ab, buf))
+}

--- a/src/crypto/key_agreement.rs
+++ b/src/crypto/key_agreement.rs
@@ -5,15 +5,13 @@ use {
         ecdsa::ECPublicKey,
         groups::{EllipticCurve, EllipticCurvePoint, ModPGroup},
         mod_ring::{ModRingElementRef, RingRefExt},
+        uint::*,
         Codec, CryptoCoreRng, PrivateKey, PublicKey,
     },
     anyhow::{anyhow, bail, ensure, Result},
     num_traits::Inv,
-    ruint::aliases::U4096,
     std::fmt::Debug,
 };
-
-type U521 = ruint::Uint<521, 9>;
 
 /// Object safe trait for key agreement algorithms
 pub trait KeyAgreementAlgorithm: Debug {
@@ -28,7 +26,7 @@ pub trait DiffieHellman {
     fn shared_secret(&self, private: &[u8], public: &[u8]) -> Result<Vec<u8>>;
 }
 
-impl KeyAgreementAlgorithm for ModPGroup<U4096, U4096> {
+impl KeyAgreementAlgorithm for ModPGroup<DhUint, DhsUint> {
     fn parse_public_key(&self, bytes: &[u8]) -> Result<PublicKey> {
         let int: ModRingElementRef<_> =
             BsiTr031111Codec::default().decode(&mut &bytes[..], self.base_field())?;
@@ -50,7 +48,7 @@ impl KeyAgreementAlgorithm for ModPGroup<U4096, U4096> {
     }
 
     fn key_agreement(&self, private: &PrivateKey, public: &PublicKey) -> Result<Vec<u8>> {
-        let private: &U4096 = private
+        let private: &DhUint = private
             .0
             .as_ref()
             .downcast_ref()
@@ -68,7 +66,7 @@ impl KeyAgreementAlgorithm for ModPGroup<U4096, U4096> {
     }
 }
 
-impl KeyAgreementAlgorithm for EllipticCurve<U521> {
+impl KeyAgreementAlgorithm for EllipticCurve<EcUint> {
     fn parse_public_key(&self, bytes: &[u8]) -> Result<PublicKey> {
         let point: EllipticCurvePoint<_> =
             BsiTr031111Codec::default().decode(&mut &bytes[..], self)?;
@@ -93,7 +91,7 @@ impl KeyAgreementAlgorithm for EllipticCurve<U521> {
             *private
                 .0
                 .as_ref()
-                .downcast_ref::<U521>()
+                .downcast_ref::<EcUint>()
                 .ok_or(anyhow!("Invalid private key"))?,
         );
         let public = if let PublicKey::EC(key) = public {
@@ -109,9 +107,9 @@ impl KeyAgreementAlgorithm for EllipticCurve<U521> {
 /// Elliptic Curve Key Agreement
 /// See TR-03111 section 4.3.1
 pub fn ecka<'a>(
-    private_key: ModRingElementRef<'a, U521>,
-    public_key: &'a ECPublicKey<U521>,
-) -> Result<(EllipticCurvePoint<'a, U521>, Vec<u8>)> {
+    private_key: ModRingElementRef<'a, EcUint>,
+    public_key: &'a ECPublicKey<EcUint>,
+) -> Result<(EllipticCurvePoint<'a, EcUint>, Vec<u8>)> {
     let curve = &public_key.curve;
     let point = public_key.point()?;
     ensure!(private_key.ring() == curve.scalar_field());

--- a/src/crypto/key_agreement.rs
+++ b/src/crypto/key_agreement.rs
@@ -17,6 +17,7 @@ type U521 = ruint::Uint<521, 9>;
 
 /// Object safe trait for key agreement algorithms
 pub trait KeyAgreementAlgorithm: Debug {
+    fn parse_public_key(&self, bytes: &[u8]) -> Result<PublicKey>;
     fn generate_key_pair(&self, rng: &mut dyn CryptoCoreRng) -> (PrivateKey, PublicKey);
     fn key_agreement(&self, private: &PrivateKey, public: &PublicKey) -> Result<Vec<u8>>;
 }
@@ -28,6 +29,16 @@ pub trait DiffieHellman {
 }
 
 impl KeyAgreementAlgorithm for ModPGroup<U4096, U4096> {
+    fn parse_public_key(&self, bytes: &[u8]) -> Result<PublicKey> {
+        let int: ModRingElementRef<_> =
+            BsiTr031111Codec::default().decode(&mut &bytes[..], self.base_field())?;
+        let dhkey = DHPublicKey {
+            group: self.clone(),
+            key:   int.to_uint(),
+        };
+        Ok(PublicKey::DH(dhkey))
+    }
+
     fn generate_key_pair(&self, rng: &mut dyn CryptoCoreRng) -> (PrivateKey, PublicKey) {
         let private = self.base_field().random(rng).to_uint();
         let public = self.generator().pow_ct(private);
@@ -58,6 +69,16 @@ impl KeyAgreementAlgorithm for ModPGroup<U4096, U4096> {
 }
 
 impl KeyAgreementAlgorithm for EllipticCurve<U521> {
+    fn parse_public_key(&self, bytes: &[u8]) -> Result<PublicKey> {
+        let point: EllipticCurvePoint<_> =
+            BsiTr031111Codec::default().decode(&mut &bytes[..], self)?;
+        let eckey = ECPublicKey {
+            curve: self.clone(),
+            point: (point.x().unwrap().to_uint(), point.y().unwrap().to_uint()),
+        };
+        Ok(PublicKey::EC(eckey))
+    }
+
     fn generate_key_pair(&self, rng: &mut dyn super::CryptoCoreRng) -> (PrivateKey, PublicKey) {
         let private = self.scalar_field().random(rng);
         let public = self.generator() * private;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -4,78 +4,59 @@
 
 pub mod certificate;
 mod codec;
+mod dh;
 mod ecdsa;
 pub mod groups;
+mod key_agreement;
 pub mod mod_ring;
 mod pki;
-pub mod public_key;
+mod public_key;
 mod rsa;
 mod signature;
 pub mod trust;
 
-pub use codec::Codec;
 use {
     crate::asn1::public_key_info::SubjectPublicKeyInfo,
-    anyhow::{ensure, Result},
+    anyhow::{bail, ensure, Result},
     der::asn1::OctetString,
     rand::{CryptoRng, RngCore},
     ruint::Uint,
-    std::{
-        any::Any,
-        fmt::{Debug, Display},
-    },
+    std::any::Any,
 };
+pub use {codec::Codec, key_agreement::KeyAgreementAlgorithm, public_key::PublicKey};
 
 pub trait CryptoCoreRng: CryptoRng + RngCore {}
 
 impl<T> CryptoCoreRng for T where T: CryptoRng + RngCore {}
 
-/// Opaque wrapper for public keys.
-///
-/// Derefs as a byte slice.
-pub struct PublicKey(Vec<u8>);
+///// Opaque wrapper for public keys.
+/////
+///// Derefs as a byte slice.
+// pub struct PublicKey(Vec<u8>);
 
 /// Opaque wrapper for private keys.
 pub struct PrivateKey(Box<dyn Any>);
 
-pub trait DiffieHellman {
-    fn generate_private_key(&self, rng: &mut dyn CryptoCoreRng) -> Vec<u8>;
-    fn private_to_public(&self, private: &[u8]) -> Result<Vec<u8>>;
-    fn shared_secret(&self, private: &[u8], public: &[u8]) -> Result<Vec<u8>>;
-}
+// impl AsRef<[u8]> for PublicKey {
+//    fn as_ref(&self) -> &[u8] {
+//        self.0.as_ref()
+//    }
+//}
 
-/// Object safe trait for key agreement algorithms
-pub trait KeyAgreementAlgorithm: Display + Debug {
-    fn subject_public_key(&self, pubkey: &SubjectPublicKeyInfo) -> Result<PublicKey>;
-    fn generate_key_pair(&self, rng: &mut dyn CryptoCoreRng) -> (PrivateKey, PublicKey);
-    fn key_agreement(&self, private: &PrivateKey, public: &PublicKey) -> Result<Vec<u8>>;
-}
-
-impl AsRef<[u8]> for PublicKey {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
+type U521 = ruint::Uint<521, 9>;
 impl SubjectPublicKeyInfo {
     /// Returns the KeyAgreementAlgorithm and public key.
     pub fn to_algorithm_public_key(&self) -> Result<(Box<dyn KeyAgreementAlgorithm>, PublicKey)> {
-        todo!()
-
-        // let algo: Box<dyn KeyAgreementAlgorithm> = match &self.algorithm {
-        //     PubkeyAlgorithmIdentifier::Dh(params) => todo!(), /*
-        // Box::new(ModPGroup::from_parameters(params)?), */
-        //     PubkeyAlgorithmIdentifier::Ec(ec) => match ec {
-        //         ECAlgoParameters::EcParameters(params) => {
-        //             Box::new(EllipticCurve::from_parameters(params)?)
-        //         }
-        //         ECAlgoParameters::NamedCurve(_) => bail!("Unknown named
-        // curve"),         ECAlgoParameters::ImplicitlyCA(_) =>
-        // bail!("Implicit CA not implemented"),     },
-        //     _ => bail!("Unknown key agreement algorithm."),
-        // };
-        // let public = algo.subject_public_key(self)?;
-        // Ok((algo, public))
+        let res: (Box<dyn KeyAgreementAlgorithm>, PublicKey) = match &self {
+            SubjectPublicKeyInfo::DH(_info) => todo!(),
+            SubjectPublicKeyInfo::EC(info) => {
+                let key = ecdsa::ECPublicKey::try_from(info.clone())?;
+                let curve = key.curve.clone();
+                (Box::new(curve), PublicKey::EC(key))
+            }
+            _ => bail!("Unknown key agreement algorithm."),
+        };
+        Ok(res)
     }
 }
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -17,10 +17,8 @@ pub mod trust;
 
 use {
     crate::asn1::public_key_info::SubjectPublicKeyInfo,
-    anyhow::{bail, ensure, Result},
-    der::asn1::OctetString,
+    anyhow::{bail, Result},
     rand::{CryptoRng, RngCore},
-    ruint::Uint,
     std::any::Any,
 };
 pub use {codec::Codec, key_agreement::KeyAgreementAlgorithm, public_key::PublicKey};
@@ -29,21 +27,21 @@ pub trait CryptoCoreRng: CryptoRng + RngCore {}
 
 impl<T> CryptoCoreRng for T where T: CryptoRng + RngCore {}
 
-///// Opaque wrapper for public keys.
-/////
-///// Derefs as a byte slice.
-// pub struct PublicKey(Vec<u8>);
-
 /// Opaque wrapper for private keys.
 pub struct PrivateKey(Box<dyn Any>);
 
-// impl AsRef<[u8]> for PublicKey {
-//    fn as_ref(&self) -> &[u8] {
-//        self.0.as_ref()
-//    }
-//}
+pub mod uint {
+    use ruint::{
+        aliases::{U2048, U256, U4096},
+        Uint,
+    };
+    type U521 = Uint<521, 9>;
+    pub type EcUint = U521;
+    pub type DhUint = U2048;
+    pub type DhsUint = U256;
+    pub type RsaUint = U4096;
+}
 
-type U521 = ruint::Uint<521, 9>;
 impl SubjectPublicKeyInfo {
     /// Returns the KeyAgreementAlgorithm and public key.
     pub fn to_algorithm_public_key(&self) -> Result<(Box<dyn KeyAgreementAlgorithm>, PublicKey)> {
@@ -58,22 +56,4 @@ impl SubjectPublicKeyInfo {
         };
         Ok(res)
     }
-}
-
-pub fn parse_uint_os<const B: usize, const L: usize>(os: &OctetString) -> Result<Uint<B, L>> {
-    // Get twos-complement big-endian bytes
-    let big_endian = os.as_bytes();
-
-    // TODO: Length should be exactly length of modulus in bytes.
-
-    // Ensure the number is not too large
-    ensure!(big_endian.len() <= 40, "Modulus is too large");
-
-    // Zero extend to 320 bits
-    let mut zero_extended = [0; 40];
-    zero_extended[40 - big_endian.len()..].copy_from_slice(big_endian);
-
-    // Parse as Uint
-    let uint = Uint::from_be_slice(&zero_extended);
-    Ok(uint)
 }

--- a/src/crypto/mod_ring/uint_mont.rs
+++ b/src/crypto/mod_ring/uint_mont.rs
@@ -21,6 +21,7 @@ pub trait UintMont:
     + ConstantTimeEq
     + ConditionallySelectable
     + UintExp
+    + TryFrom<der::asn1::Int>
 {
     fn parameters_from_modulus(modulus: Self) -> ModRing<Self>;
     fn from_u64(value: u64) -> Self;

--- a/src/crypto/public_key.rs
+++ b/src/crypto/public_key.rs
@@ -5,6 +5,7 @@ use {
         ecdsa::{ECPublicKey, ECSignature},
         mod_ring::RingRefExt,
         rsa::RSAPublicKey,
+        uint::*,
     },
     crate::asn1::{
         public_key_info::SubjectPublicKeyInfo, signature_algorithm_identifier::EcdsaSigValue,
@@ -12,16 +13,13 @@ use {
     },
     anyhow::{bail, Result},
     der::{Decode, Encode},
-    ruint::{aliases::*, Uint},
 };
-
-type U521 = Uint<521, 9>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PublicKey {
-    DH(DHPublicKey<U4096, U4096>),
-    EC(ECPublicKey<U521>),
-    RSA(RSAPublicKey<U4096>),
+    DH(DHPublicKey<DhUint, DhsUint>),
+    EC(ECPublicKey<EcUint>),
+    RSA(RSAPublicKey<RsaUint>),
 }
 
 impl PublicKey {
@@ -38,11 +36,11 @@ impl PublicKey {
                 let r_elem = key
                     .curve
                     .scalar_field()
-                    .from(U521::from_be_slice(&r.as_bytes()));
+                    .from(EcUint::from_be_slice(&r.as_bytes()));
                 let s_elem = key
                     .curve
                     .scalar_field()
-                    .from(U521::from_be_slice(&s.as_bytes()));
+                    .from(EcUint::from_be_slice(&s.as_bytes()));
                 let ecsig = ECSignature {
                     r: r_elem,
                     s: s_elem,
@@ -51,7 +49,7 @@ impl PublicKey {
                 key.verify(message, &ecsig, signature_algorithm)
             }
             PublicKey::RSA(key) => {
-                let sigint = U4096::from_be_slice(&signature);
+                let sigint = RsaUint::from_be_slice(&signature);
                 let rsasig = key.ring.from(sigint);
 
                 key.verify(message, rsasig, signature_algorithm)

--- a/src/crypto/public_key.rs
+++ b/src/crypto/public_key.rs
@@ -1,5 +1,7 @@
 use {
     super::{
+        codec::{BsiTr031111Codec, BufMutCodec},
+        dh::DHPublicKey,
         ecdsa::{ECPublicKey, ECSignature},
         mod_ring::RingRefExt,
         rsa::RSAPublicKey,
@@ -8,7 +10,7 @@ use {
         public_key_info::SubjectPublicKeyInfo, signature_algorithm_identifier::EcdsaSigValue,
         SignatureAlgorithmIdentifier,
     },
-    anyhow::Result,
+    anyhow::{bail, Result},
     der::{Decode, Encode},
     ruint::{aliases::*, Uint},
 };
@@ -17,11 +19,13 @@ type U521 = Uint<521, 9>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PublicKey {
+    DH(DHPublicKey<U4096, U4096>),
     EC(ECPublicKey<U521>),
     RSA(RSAPublicKey<U4096>),
 }
 
 impl PublicKey {
+    /// Verify a signature
     pub fn verify(
         &self,
         message: &[u8],
@@ -52,6 +56,26 @@ impl PublicKey {
 
                 key.verify(message, rsasig, signature_algorithm)
             }
+            _ => bail!("Not possible verifying signatures with {:?}", self),
+        }
+    }
+
+    /// Returns the public key as bytes following the BSI TR-03111
+    /// representation
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let codec = BsiTr031111Codec::default();
+        match self {
+            PublicKey::DH(key) => {
+                let mut bytes = Vec::new();
+                bytes.put_codec(&codec, key.key);
+                bytes
+            }
+            PublicKey::EC(key) => {
+                let mut bytes = Vec::new();
+                bytes.put_codec(&codec, key.point().unwrap());
+                bytes
+            }
+            _ => todo!(),
         }
     }
 }

--- a/src/emrtd/chip_authentication.rs
+++ b/src/emrtd/chip_authentication.rs
@@ -41,7 +41,7 @@ impl Emrtd {
         self.mset_at(ca.protocol.into(), pk.key_id)?;
 
         // Send the public key using general authenticate
-        let data = self.general_authenticate(public_key.as_ref())?;
+        let data = self.general_authenticate(&public_key.to_bytes())?;
         println!("==> General Authenticate: {}", hex::encode(data));
 
         // Keys should now have been changed.


### PR DESCRIPTION
Brings back `trait KeyAgreementAlgorithm` implementations, tested only for ECDH.