### PR TITLE
Add `MrzInfo` helper

### DIFF
--- a/src/bin/reader.rs
+++ b/src/bin/reader.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
 
     // println!("=== Basic Access Control.");
     let mrz = env::var("MRZ")?;
-    card.basic_access_control(&mut rng, &mrz)
+    card.basic_access_control(&mut rng, &mrz.try_into()?)
         .context("Error during Basic Access Control.")?;
     eprintln!("Basic Access Control successful.");
 

--- a/src/emrtd/bac.rs
+++ b/src/emrtd/bac.rs
@@ -2,7 +2,7 @@ use {
     super::{
         pad,
         secure_messaging::{tdes::TDesCipher, Cipher, Encrypted},
-        seed_from_mrz, Emrtd,
+        Emrtd, MrzInfo,
     },
     anyhow::{anyhow, ensure, Result},
     rand::Rng,
@@ -35,13 +35,13 @@ impl Emrtd {
         Ok(data)
     }
 
-    pub fn basic_access_control(&mut self, rng: &mut impl Rng, mrz: &str) -> Result<()> {
+    pub fn basic_access_control(&mut self, rng: &mut impl Rng, mrz: &MrzInfo) -> Result<()> {
         // Compute local randomness
         let rnd_ifd: [u8; 8] = rng.gen();
         let k_ifd: [u8; 16] = rng.gen();
 
         // Compute encryption / authentication keys from MRZ
-        let seed = seed_from_mrz(mrz);
+        let seed = mrz.seed();
         let cipher = TDesCipher::from_seed(&seed);
 
         // GET CHALLENGE

--- a/src/emrtd/mod.rs
+++ b/src/emrtd/mod.rs
@@ -3,10 +3,14 @@
 mod bac;
 mod chip_authentication;
 mod files;
+mod mrz;
 mod pace;
 pub mod secure_messaging;
 
-pub use self::files::{DedicatedId, FileId, HasFileId};
+pub use self::{
+    files::{DedicatedId, FileId, HasFileId},
+    mrz::MrzInfo,
+};
 use {
     self::secure_messaging::{PlainText, SecureMessaging},
     crate::{
@@ -39,6 +43,9 @@ pub struct Emrtd {
 pub enum Error {
     #[error("NFC error: {0}")]
     NfcError(anyhow::Error),
+
+    #[error("MRZ parsing error: {0}")]
+    InvalidMRZ(anyhow::Error),
 
     #[error("Response Status: {0}")]
     ErrorResponse(StatusWord),
@@ -133,11 +140,4 @@ impl Emrtd {
 pub fn pad(bytes: &mut Vec<u8>, block_size: usize) {
     bytes.push(0x80);
     bytes.resize(bytes.len().next_multiple_of(block_size), 0x00);
-}
-
-pub fn seed_from_mrz(mrz: &str) -> [u8; 16] {
-    let mut hasher = Sha1::new();
-    hasher.update(mrz.as_bytes());
-    let hash = hasher.finalize();
-    hash[0..16].try_into().unwrap()
 }

--- a/src/emrtd/mrz.rs
+++ b/src/emrtd/mrz.rs
@@ -1,0 +1,132 @@
+use {
+    super::{Error, Result},
+    anyhow::anyhow,
+    sha1::{Digest, Sha1},
+    std::{
+        fmt::{self, Display},
+        iter::repeat,
+    },
+};
+
+#[derive(Clone, Debug)]
+pub struct MrzInfo {
+    info: String,
+}
+
+impl MrzInfo {
+    /// Constructs MRZ information from visible document details.
+    /// The input document number `docno` can be under padded.
+    pub fn from_details(docno: &str, birthdate: &str, expirydate: &str) -> Result<Self> {
+        // Validate inputs
+        if !Self::has_valid_chars(docno) {
+            return Err(Error::InvalidMRZ(anyhow!("Invalid document number")));
+        }
+        if birthdate.len() != 6 || !Self::has_valid_chars(birthdate) {
+            return Err(Error::InvalidMRZ(anyhow!("Invalid birth date")));
+        }
+        if expirydate.len() != 6 || !Self::has_valid_chars(expirydate) {
+            return Err(Error::InvalidMRZ(anyhow!("Invalid expiry date")));
+        }
+
+        let mut info = String::new();
+        info.push_str(docno);
+        if docno.len() < 9 {
+            info.extend(repeat('<').take(9 - docno.len()))
+        };
+        info.push(Self::check_digit(docno));
+
+        info.push_str(birthdate);
+        info.push(Self::check_digit(birthdate));
+
+        info.push_str(expirydate);
+        info.push(Self::check_digit(expirydate));
+
+        Ok(Self { info })
+    }
+
+    pub fn seed(&self) -> [u8; 16] {
+        let mut hasher = Sha1::new();
+        hasher.update(self.info.as_bytes());
+        let hash = hasher.finalize();
+        hash[0..16].try_into().unwrap()
+    }
+
+    fn check_digit(str: &str) -> char {
+        let weights = [7, 3, 1];
+        let result = str.chars().enumerate().fold(0, |acc, (i, c)| {
+            let digit = Self::char_to_value(c);
+            (acc + weights[i % 3] * digit) % 10
+        });
+
+        char::from_digit(result as u32, 10).unwrap_or('<')
+    }
+
+    fn char_to_value(c: char) -> i32 {
+        match c {
+            '0'..='9' => c.to_digit(10).unwrap() as i32,
+            'A'..='Z' => (c as u8 - b'A' + 10) as i32,
+            '<' => 0,
+            _ => panic!("Invalid MRZ character"),
+        }
+    }
+
+    fn has_valid_chars(s: &str) -> bool {
+        s.chars().all(|c| matches!(c, '0'..='9' | 'A'..='Z' | '<'))
+    }
+}
+
+impl Display for MrzInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.info)
+    }
+}
+
+impl AsRef<str> for MrzInfo {
+    fn as_ref(&self) -> &str {
+        &self.info
+    }
+}
+
+impl TryFrom<&str> for MrzInfo {
+    type Error = Error;
+    fn try_from(val: &str) -> Result<Self> {
+        if Self::has_valid_chars(val) {
+            Ok(Self { info: val.into() })
+        } else {
+            Err(Error::InvalidMRZ(anyhow!(
+                "MRZ info has invalid characters"
+            )))
+        }
+    }
+}
+
+impl TryFrom<String> for MrzInfo {
+    type Error = Error;
+    fn try_from(val: String) -> Result<Self> {
+        Self::try_from(val.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mrz_from_details() {
+        let cases = [
+            ("L898902C3", "740812", "250415", "L898902C3674081222504155"),
+            ("L898902C", "690806", "940623", "L898902C<369080619406236"),
+            (
+                "D23145890734",
+                "340712",
+                "950712",
+                "D23145890734934071279507122",
+            ),
+        ];
+
+        for (docno, birth, expiry, expected) in cases {
+            let mrz = MrzInfo::from_details(docno, birth, expiry).unwrap();
+            assert_eq!(mrz.to_string(), expected);
+        }
+    }
+}

--- a/src/emrtd/secure_messaging/tdes.rs
+++ b/src/emrtd/secure_messaging/tdes.rs
@@ -91,15 +91,15 @@ fn set_parity_bits(key: &mut [u8]) {
 mod tests {
     use {
         super::{super::SecureMessaging, *},
-        crate::emrtd::{pad, secure_messaging::Encrypted, seed_from_mrz},
+        crate::emrtd::{pad, secure_messaging::Encrypted, MrzInfo},
         hex_literal::hex,
     };
 
     /// Example from ICAO 9303-11 section D.2
     #[test]
     fn test_bac_example() {
-        let mrz = "L898902C<369080619406236";
-        let seed = seed_from_mrz(mrz);
+        let mrz = MrzInfo::try_from("L898902C<369080619406236").unwrap();
+        let seed = mrz.seed();
         assert_eq!(seed, hex!("239AB9CB282DAF66231DC5A4DF6BFBAE"));
 
         let (kenc, kmac) = (kdf(&seed, KDF_ENC), kdf(&seed, KDF_MAC));


### PR DESCRIPTION
Adds an helper to combine visible details, making MRZ information construction a bit easier.