### PR TITLE
PublicKey as trait

### DIFF
--- a/src/crypto/codec/bsi_tr03111.rs
+++ b/src/crypto/codec/bsi_tr03111.rs
@@ -148,7 +148,7 @@ pub fn parse_ec_point<'a, U: UintMont>(curve: &'a EllipticCurve<U>, os: &[u8]) -
                 .to_uint();
             Ok((x, y))
         }
-        4 => parse_ec_point_uncompressed(coords),
+        4 => parse_ec_point_uncompressed(os),
         _ => bail!("Invalid byte for elliptic curve point"),
     }
 }

--- a/src/crypto/key_agreement.rs
+++ b/src/crypto/key_agreement.rs
@@ -5,7 +5,6 @@ use {
         ecdsa::ECPublicKey,
         groups::{EllipticCurve, EllipticCurvePoint, ModPGroup},
         mod_ring::{ModRingElementRef, RingRefExt},
-        uint::*,
         Codec, CryptoCoreRng, PrivateKey, PublicKey,
     },
     anyhow::{anyhow, bail, ensure, Result},
@@ -26,55 +25,59 @@ pub trait DiffieHellman {
     fn shared_secret(&self, private: &[u8], public: &[u8]) -> Result<Vec<u8>>;
 }
 
-impl KeyAgreementAlgorithm for ModPGroup<DhUint, DhsUint> {
+// impl KeyAgreementAlgorithm for ModPGroup<DhUint, DhsUint> {
+//    fn parse_public_key(&self, bytes: &[u8]) -> Result<PublicKey> {
+//        let int: ModRingElementRef<_> =
+//            BsiTr031111Codec::default().decode(&mut &bytes[..],
+// self.base_field())?;        let dhkey = DHPublicKey {
+//            group: self.clone(),
+//            key:   int.to_uint(),
+//        };
+//        Ok(PublicKey::DH(dhkey))
+//    }
+//
+//    fn generate_key_pair(&self, rng: &mut dyn CryptoCoreRng) -> (PrivateKey,
+// PublicKey) {        let private = self.base_field().random(rng).to_uint();
+//        let public = self.generator().pow_ct(private);
+//        let public = PublicKey::DH(DHPublicKey {
+//            group: self.clone(),
+//            key:   public.to_uint(),
+//        });
+//        (PrivateKey(Box::new(private)), public)
+//    }
+//
+//    fn key_agreement(&self, private: &PrivateKey, public: &PublicKey) ->
+// Result<Vec<u8>> {        let private: &DhUint = private
+//            .0
+//            .as_ref()
+//            .downcast_ref()
+//            .ok_or(anyhow!("Invalid private key"))?;
+//        let public = if let PublicKey::DH(key) = public {
+//            key
+//        } else {
+//            bail!("Provided public key is not EC")
+//        };
+//        let key = public.group.base_field().from(public.key);
+//        let shared = key.pow_ct(*private);
+//        let mut buf = Vec::new();
+//        BsiTr031111Codec::default().encode(&mut buf, shared);
+//        Ok(buf)
+//    }
+//}
+
+impl<U: crate::crypto::mod_ring::UintMont> KeyAgreementAlgorithm for EllipticCurve<U> {
     fn parse_public_key(&self, bytes: &[u8]) -> Result<PublicKey> {
-        let int: ModRingElementRef<_> =
-            BsiTr031111Codec::default().decode(&mut &bytes[..], self.base_field())?;
-        let dhkey = DHPublicKey {
-            group: self.clone(),
-            key:   int.to_uint(),
-        };
-        Ok(PublicKey::DH(dhkey))
-    }
-
-    fn generate_key_pair(&self, rng: &mut dyn CryptoCoreRng) -> (PrivateKey, PublicKey) {
-        let private = self.base_field().random(rng).to_uint();
-        let public = self.generator().pow_ct(private);
-        let public = PublicKey::DH(DHPublicKey {
-            group: self.clone(),
-            key:   public.to_uint(),
-        });
-        (PrivateKey(Box::new(private)), public)
-    }
-
-    fn key_agreement(&self, private: &PrivateKey, public: &PublicKey) -> Result<Vec<u8>> {
-        let private: &DhUint = private
-            .0
-            .as_ref()
-            .downcast_ref()
-            .ok_or(anyhow!("Invalid private key"))?;
-        let public = if let PublicKey::DH(key) = public {
-            key
-        } else {
-            bail!("Provided public key is not EC")
-        };
-        let key = public.group.base_field().from(public.key);
-        let shared = key.pow_ct(*private);
-        let mut buf = Vec::new();
-        BsiTr031111Codec::default().encode(&mut buf, shared);
-        Ok(buf)
-    }
-}
-
-impl KeyAgreementAlgorithm for EllipticCurve<EcUint> {
-    fn parse_public_key(&self, bytes: &[u8]) -> Result<PublicKey> {
-        let point: EllipticCurvePoint<_> =
-            BsiTr031111Codec::default().decode(&mut &bytes[..], self)?;
+        let point = self.generator();
+        // let point: EllipticCurvePoint<_> =
+        //    BsiTr031111Codec::default().decode(&mut &bytes[..], self)?;
         let eckey = ECPublicKey {
             curve: self.clone(),
-            point: (point.x().unwrap().to_uint(), point.y().unwrap().to_uint()),
+            point: (
+                U::from_be_bytes(&point.x().unwrap().to_uint().to_be_bytes()),
+                U::from_be_bytes(&point.y().unwrap().to_uint().to_be_bytes()),
+            ),
         };
-        Ok(PublicKey::EC(eckey))
+        Ok(Box::new(eckey))
     }
 
     fn generate_key_pair(&self, rng: &mut dyn super::CryptoCoreRng) -> (PrivateKey, PublicKey) {
@@ -82,43 +85,11 @@ impl KeyAgreementAlgorithm for EllipticCurve<EcUint> {
         let public = self.generator() * private;
         (
             PrivateKey(Box::new(private.as_montgomery())),
-            PublicKey::EC(public.into()),
+            Box::new(ECPublicKey::from(public)),
         )
     }
 
     fn key_agreement(&self, private: &PrivateKey, public: &PublicKey) -> Result<Vec<u8>> {
-        let private = self.scalar_field().from_montgomery(
-            *private
-                .0
-                .as_ref()
-                .downcast_ref::<EcUint>()
-                .ok_or(anyhow!("Invalid private key"))?,
-        );
-        let public = if let PublicKey::EC(key) = public {
-            key
-        } else {
-            bail!("Provided public key is not EC")
-        };
-        let (_, shared) = ecka(private, public)?;
-        Ok(shared)
+        public.key_agreement(private)
     }
-}
-
-/// Elliptic Curve Key Agreement
-/// See TR-03111 section 4.3.1
-pub fn ecka<'a>(
-    private_key: ModRingElementRef<'a, EcUint>,
-    public_key: &'a ECPublicKey<EcUint>,
-) -> Result<(EllipticCurvePoint<'a, EcUint>, Vec<u8>)> {
-    let curve = &public_key.curve;
-    let point = public_key.point()?;
-    ensure!(private_key.ring() == curve.scalar_field());
-    let h = curve.cofactor();
-    let l = curve.scalar_field().from(h).inv().unwrap();
-    let q = point.mul_uint(h);
-    let s_ab = q * (private_key * l);
-    ensure!(s_ab != curve.infinity());
-    let mut buf = Vec::new();
-    BsiTr031111Codec::default().encode(&mut buf, s_ab.x().unwrap());
-    Ok((s_ab, buf))
 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -9,6 +9,7 @@ mod ecdsa;
 pub mod groups;
 mod key_agreement;
 pub mod mod_ring;
+mod named_curves;
 mod pki;
 mod public_key;
 mod rsa;
@@ -16,7 +17,8 @@ mod signature;
 pub mod trust;
 
 use {
-    crate::asn1::public_key_info::SubjectPublicKeyInfo,
+    self::{ecdsa::ECPublicKey, named_curves::*},
+    crate::asn1::public_key_info::{ECAlgoParameters, EcPublicKeyInfo, SubjectPublicKeyInfo},
     anyhow::{bail, Result},
     rand::{CryptoRng, RngCore},
     std::any::Any,
@@ -30,30 +32,132 @@ impl<T> CryptoCoreRng for T where T: CryptoRng + RngCore {}
 /// Opaque wrapper for private keys.
 pub struct PrivateKey(Box<dyn Any>);
 
-pub mod uint {
-    use ruint::{
-        aliases::{U2048, U256, U4096},
-        Uint,
-    };
-    type U521 = Uint<521, 9>;
-    pub type EcUint = U521;
-    pub type DhUint = U2048;
-    pub type DhsUint = U256;
-    pub type RsaUint = U4096;
-}
-
 impl SubjectPublicKeyInfo {
     /// Returns the KeyAgreementAlgorithm and public key.
     pub fn to_algorithm_public_key(&self) -> Result<(Box<dyn KeyAgreementAlgorithm>, PublicKey)> {
-        let res: (Box<dyn KeyAgreementAlgorithm>, PublicKey) = match &self {
+        match self {
             SubjectPublicKeyInfo::DH(_info) => todo!(),
-            SubjectPublicKeyInfo::EC(info) => {
-                let key = ecdsa::ECPublicKey::try_from(info.clone())?;
-                let curve = key.curve.clone();
-                (Box::new(curve), PublicKey::EC(key))
-            }
+            SubjectPublicKeyInfo::EC((params, info)) => create_ec_key_by_size(params, info),
             _ => bail!("Unknown key agreement algorithm."),
-        };
-        Ok(res)
+        }
+    }
+}
+
+use ruint::{aliases::*, Uint};
+type U224 = Uint<224, 4>;
+type U521 = Uint<521, 9>;
+
+fn create_ec_key_by_size(
+    params: &ECAlgoParameters,
+    info: &EcPublicKeyInfo,
+) -> Result<(Box<dyn KeyAgreementAlgorithm>, PublicKey)> {
+    match params {
+        ECAlgoParameters::NamedCurve(oid) => match *oid {
+            ID_SEC_P521R1 => {
+                let key = ECPublicKey::<U521>::try_from((params.clone(), info.clone()))?;
+                let curve = key.curve.clone();
+                Ok((Box::new(curve), Box::new(key)))
+            }
+            ID_BRAINPOOL_P512R1 => {
+                let key = ECPublicKey::<U512>::try_from((params.clone(), info.clone()))?;
+                let curve = key.curve.clone();
+                Ok((Box::new(curve), Box::new(key)))
+            }
+            ID_SEC_P384R1 | ID_BRAINPOOL_P384R1 => {
+                let key = ECPublicKey::<U384>::try_from((params.clone(), info.clone()))?;
+                let curve = key.curve.clone();
+                Ok((Box::new(curve), Box::new(key)))
+            }
+            ID_SEC_P256R1 | ID_BRAINPOOL_P256R1 => {
+                let key = ECPublicKey::<U256>::try_from((params.clone(), info.clone()))?;
+                let curve = key.curve.clone();
+                Ok((Box::new(curve), Box::new(key)))
+            }
+            ID_SEC_P224R1 | ID_BRAINPOOL_P224R1 => {
+                let key = ECPublicKey::<U224>::try_from((params.clone(), info.clone()))?;
+                let curve = key.curve.clone();
+                Ok((Box::new(curve), Box::new(key)))
+            }
+            ID_SEC_P192R1 | ID_BRAINPOOL_P192R1 => {
+                let key = ECPublicKey::<U192>::try_from((params.clone(), info.clone()))?;
+                let curve = key.curve.clone();
+                Ok((Box::new(curve), Box::new(key)))
+            }
+            ID_BRAINPOOL_P320R1 => {
+                let key = ECPublicKey::<U320>::try_from((params.clone(), info.clone()))?;
+                let curve = key.curve.clone();
+                Ok((Box::new(curve), Box::new(key)))
+            }
+            ID_BRAINPOOL_P160R1 => {
+                let key = ECPublicKey::<U160>::try_from((params.clone(), info.clone()))?;
+                let curve = key.curve.clone();
+                Ok((Box::new(curve), Box::new(key)))
+            }
+            _ => bail!("Unsupported curve OID: {}", oid),
+        },
+        ECAlgoParameters::EcParameters(eparams) => {
+            match &eparams.field_id {
+                crate::asn1::public_key_info::FieldId::PrimeField { modulus } => {
+                    use crate::crypto::mod_ring::UintExp;
+                    let size = U521::try_from(modulus)?.significant_bits(); // TODO fix
+                    println!("size: {size}");
+                    match size {
+                        521 => {
+                            let key =
+                                ECPublicKey::<U521>::try_from((params.clone(), info.clone()))?;
+                            let curve = key.curve.clone();
+                            Ok((Box::new(curve), Box::new(key)))
+                        }
+                        512 => {
+                            let key =
+                                ECPublicKey::<U512>::try_from((params.clone(), info.clone()))?;
+                            let curve = key.curve.clone();
+                            Ok((Box::new(curve), Box::new(key)))
+                        }
+                        384 => {
+                            let key =
+                                ECPublicKey::<U384>::try_from((params.clone(), info.clone()))?;
+                            let curve = key.curve.clone();
+                            Ok((Box::new(curve), Box::new(key)))
+                        }
+                        320 => {
+                            let key =
+                                ECPublicKey::<U320>::try_from((params.clone(), info.clone()))?;
+                            let curve = key.curve.clone();
+                            Ok((Box::new(curve), Box::new(key)))
+                        }
+                        256 => {
+                            let key =
+                                ECPublicKey::<U256>::try_from((params.clone(), info.clone()))?;
+                            let curve = key.curve.clone();
+                            Ok((Box::new(curve), Box::new(key)))
+                        }
+                        224 => {
+                            let key =
+                                ECPublicKey::<U224>::try_from((params.clone(), info.clone()))?;
+                            let curve = key.curve.clone();
+                            Ok((Box::new(curve), Box::new(key)))
+                        }
+                        192 => {
+                            let key =
+                                ECPublicKey::<U192>::try_from((params.clone(), info.clone()))?;
+                            let curve = key.curve.clone();
+                            Ok((Box::new(curve), Box::new(key)))
+                        }
+                        160 => {
+                            let key =
+                                ECPublicKey::<U160>::try_from((params.clone(), info.clone()))?;
+                            let curve = key.curve.clone();
+                            Ok((Box::new(curve), Box::new(key)))
+                        }
+                        _ => bail!("Unsupported field size: {}", size),
+                    }
+                }
+                crate::asn1::public_key_info::FieldId::Unknown(any) => {
+                    bail!("Unsupported field type: {}", any.field_type)
+                }
+            }
+        }
+        ECAlgoParameters::ImplicitlyCA(_) => bail!("ImplicitlyCA parameters not supported"),
     }
 }

--- a/src/crypto/mod_ring/uint_mont.rs
+++ b/src/crypto/mod_ring/uint_mont.rs
@@ -13,6 +13,7 @@ use {
 /// const-generic parameters everywhere.
 pub trait UintMont:
     Sized
+    + 'static
     + Copy
     + PartialEq
     + Eq
@@ -142,7 +143,8 @@ impl<const BITS: usize, const LIMBS: usize> UintMont for Uint<BITS, LIMBS> {
 
     #[inline]
     fn from_be_bytes(bytes: &[u8]) -> Self {
-        Self::from_be_slice(bytes)
+        let init = bytes.iter().position(|x| *x != 0).unwrap_or(0);
+        Self::from_be_slice(&bytes[init..])
     }
 
     #[inline]

--- a/src/crypto/public_key.rs
+++ b/src/crypto/public_key.rs
@@ -3,78 +3,126 @@ use {
         codec::{BsiTr031111Codec, BufMutCodec},
         dh::DHPublicKey,
         ecdsa::{ECPublicKey, ECSignature},
-        mod_ring::RingRefExt,
+        groups::{EllipticCurve, EllipticCurvePoint},
+        mod_ring::{ModRingElementRef, RingRefExt, UintMont},
         rsa::RSAPublicKey,
-        uint::*,
+        PrivateKey,
     },
     crate::asn1::{
         public_key_info::SubjectPublicKeyInfo, signature_algorithm_identifier::EcdsaSigValue,
         SignatureAlgorithmIdentifier,
     },
-    anyhow::{bail, Result},
+    anyhow::{anyhow, bail, ensure, Result},
     der::{Decode, Encode},
+    num_traits::Inv,
 };
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum PublicKey {
-    DH(DHPublicKey<DhUint, DhsUint>),
-    EC(ECPublicKey<EcUint>),
-    RSA(RSAPublicKey<RsaUint>),
-}
+pub type PublicKey = Box<dyn PubKey>;
 
-impl PublicKey {
+/// Trait for public keys that can be used for cryptographic operations
+pub trait PubKey {
     /// Verify a signature
-    pub fn verify(
+    fn verify(
         &self,
         message: &[u8],
         signature: &[u8],
         signature_algorithm: &SignatureAlgorithmIdentifier,
-    ) -> Result<()> {
-        match self {
-            PublicKey::EC(key) => {
-                let EcdsaSigValue { r, s } = EcdsaSigValue::from_der(signature)?;
-                let r_elem = key
-                    .curve
-                    .scalar_field()
-                    .from(EcUint::from_be_slice(&r.as_bytes()));
-                let s_elem = key
-                    .curve
-                    .scalar_field()
-                    .from(EcUint::from_be_slice(&s.as_bytes()));
-                let ecsig = ECSignature {
-                    r: r_elem,
-                    s: s_elem,
-                };
-
-                key.verify(message, &ecsig, signature_algorithm)
-            }
-            PublicKey::RSA(key) => {
-                let sigint = RsaUint::from_be_slice(&signature);
-                let rsasig = key.ring.from(sigint);
-
-                key.verify(message, rsasig, signature_algorithm)
-            }
-            _ => bail!("Not possible verifying signatures with {:?}", self),
-        }
-    }
+    ) -> Result<()>;
 
     /// Returns the public key as bytes following the BSI TR-03111
     /// representation
-    pub fn to_bytes(&self) -> Vec<u8> {
+    fn to_bytes(&self) -> Vec<u8>;
+
+    /// Perform a key agreement with another private key
+    fn key_agreement(&self, private: &PrivateKey) -> Result<Vec<u8>>;
+}
+
+// Implement for each key type with UintMont constraint
+impl<U: UintMont, S: UintMont> PubKey for DHPublicKey<U, S> {
+    fn verify(
+        &self,
+        _message: &[u8],
+        _signature: &[u8],
+        _algorithm: &SignatureAlgorithmIdentifier,
+    ) -> Result<()> {
+        bail!("DH keys cannot verify signatures")
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
         let codec = BsiTr031111Codec::default();
-        match self {
-            PublicKey::DH(key) => {
-                let mut bytes = Vec::new();
-                bytes.put_codec(&codec, key.key);
-                bytes
-            }
-            PublicKey::EC(key) => {
-                let mut bytes = Vec::new();
-                bytes.put_codec(&codec, key.point().unwrap());
-                bytes
-            }
-            _ => todo!(),
-        }
+        let mut bytes = Vec::new();
+        // bytes.put_codec(&codec, &self.key);
+        bytes
+    }
+
+    fn key_agreement(&self, _private: &PrivateKey) -> Result<Vec<u8>> {
+        bail!("DH keys cannot perform key agreement")
+    }
+}
+
+impl<U: UintMont> PubKey for ECPublicKey<U> {
+    fn verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        algorithm: &SignatureAlgorithmIdentifier,
+    ) -> Result<()> {
+        let EcdsaSigValue { r, s } = EcdsaSigValue::from_der(signature)?;
+        let r_elem = self
+            .curve
+            .scalar_field()
+            .from(U::from_be_bytes(&r.as_bytes()));
+        let s_elem = self
+            .curve
+            .scalar_field()
+            .from(U::from_be_bytes(&s.as_bytes()));
+        let ecsig = ECSignature {
+            r: r_elem,
+            s: s_elem,
+        };
+
+        self.verify(message, &ecsig, algorithm)
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let codec = BsiTr031111Codec::default();
+        let mut bytes = Vec::new();
+        // bytes.put_codec(&codec, self.point()?);
+        bytes
+    }
+
+    fn key_agreement(&self, private: &PrivateKey) -> Result<Vec<u8>> {
+        let private = self.curve.scalar_field().from_montgomery(
+            *private
+                .0
+                .as_ref()
+                .downcast_ref::<U>()
+                .ok_or(anyhow!("Invalid private key"))?,
+        );
+        let (_, shared) = ecka(private, self)?;
+        Ok(shared)
+    }
+}
+
+impl<U: UintMont> PubKey for RSAPublicKey<U> {
+    fn verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        algorithm: &SignatureAlgorithmIdentifier,
+    ) -> Result<()> {
+        let sigint = U::from_be_bytes(signature);
+        let rsasig = self.ring.from(sigint);
+
+        self.verify(message, rsasig, algorithm)
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        todo!("Implement RSA public key serialization")
+    }
+
+    fn key_agreement(&self, private: &PrivateKey) -> Result<Vec<u8>> {
+        todo!("Implement RSA key agreement")
     }
 }
 
@@ -82,13 +130,7 @@ impl TryFrom<SubjectPublicKeyInfo> for PublicKey {
     type Error = anyhow::Error;
 
     fn try_from(info: SubjectPublicKeyInfo) -> Result<Self> {
-        match info {
-            SubjectPublicKeyInfo::RSA(key) => Ok(Self::RSA(key.try_into()?)),
-            SubjectPublicKeyInfo::EC(key) => Ok(Self::EC(key.try_into()?)),
-            other => todo!(
-                "SubjectPublicKeyInfo-variant supported for into-PublicKey conversion: {other:?}"
-            ),
-        }
+        Ok(info.to_algorithm_public_key()?.1)
     }
 }
 
@@ -99,4 +141,23 @@ impl TryFrom<&spki::SubjectPublicKeyInfoOwned> for PublicKey {
         let local_info = SubjectPublicKeyInfo::from_der(&info.to_der()?)?;
         local_info.try_into()
     }
+}
+
+/// Elliptic Curve Key Agreement
+/// See TR-03111 section 4.3.1
+pub fn ecka<'a, U: UintMont>(
+    private_key: ModRingElementRef<'a, U>,
+    public_key: &'a ECPublicKey<U>,
+) -> Result<(EllipticCurvePoint<'a, U>, Vec<u8>)> {
+    let curve = &public_key.curve;
+    let point = public_key.point()?;
+    ensure!(private_key.ring() == curve.scalar_field());
+    let h = curve.cofactor();
+    let l = curve.scalar_field().from(h).inv().unwrap();
+    let q = point.mul_uint(h);
+    let s_ab = q * (private_key * l);
+    ensure!(s_ab != curve.infinity());
+    let mut buf = Vec::new();
+    // BsiTr031111Codec::default().encode(&mut buf, s_ab.x().unwrap());
+    Ok((s_ab, buf))
 }


### PR DESCRIPTION
Just an idea, we can operate always using the most suitable Uint size, instead of using the max Uint for RSA, ECs, etc. Related cryptographic operations should be faster, at the small expense of additional `dyn`amic dispatch and code complexity.