### PR TITLE
Parse EFs DG3, DG4

### DIFF
--- a/src/asn1/emrtd/datagroups/biometric.rs
+++ b/src/asn1/emrtd/datagroups/biometric.rs
@@ -36,8 +36,7 @@ pub struct BiometricHeader<S: BiometricSubtyped = BiometricSubtype> {
     #[asn1(context_specific = "1", optional = "true")]
     pub btype:         Option<OctetString>, // '01-03' length
     /// Biometric sub-type
-    //#[asn1(context_specific = "2", optional = "true")]
-    pub bsubtype: S, // '01' length
+    pub bsubtype:      S, // '01' length
     /// Creation date and time
     #[asn1(context_specific = "3", optional = "true")]
     pub creation_date: Option<OctetString>, // '07' length
@@ -178,6 +177,19 @@ impl<'a, S: BiometricSubtyped> Decode<'a> for BiometricInformationGroup<S> {
             };
 
             insts.push(BiometricInformation { header, data });
+        }
+
+        // Encoding of zero instance, recommended tag 0x53 with random data
+        if no_inst == 0 && reader.remaining_len() > 0u8.into() {
+            let tag_53 = reader.read_byte()?;
+            if tag_53 != 0x53 {
+                return Err(Error::new(ErrorKind::TagNumberInvalid, reader.position()));
+            };
+            let len = Length::decode(reader)?;
+            OctetString::decode_value(reader, der::Header {
+                tag:    der::Tag::Null, // 0x53
+                length: len,
+            })?;
         }
 
         Ok(Self(insts))

--- a/src/asn1/emrtd/datagroups/biometric.rs
+++ b/src/asn1/emrtd/datagroups/biometric.rs
@@ -1,28 +1,34 @@
+/// ! Common data for DG2, DG3, and DG4.
 use der::{
-    self, asn1::OctetString, Decode, DecodeValue, Encode, Error, ErrorKind, Length, Reader,
-    Sequence, Writer,
+    self, asn1::OctetString, Decode, DecodeValue, Encode, EncodeValue, Error, ErrorKind, Length,
+    Reader, Sequence, Writer,
 };
 
 /// Biometric Information Template Group
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct BiometricInformationGroup(Vec<BiometricInformation>);
+pub struct BiometricInformationGroup<S: BiometricSubtyped>(Vec<BiometricInformation<S>>);
 
 /// Codec helper for Data Groups which employ Biometric Information Template
 /// Groups
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct BiometricInformationGroupTagged<const TAG: u8>(BiometricInformationGroup);
+pub(crate) struct BiometricInformationGroupTagged<const TAG: u8, S: BiometricSubtyped>(
+    BiometricInformationGroup<S>,
+);
 
 /// Biometric Information Template
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct BiometricInformation {
-    pub header: BiometricHeader,
+pub struct BiometricInformation<S: BiometricSubtyped> {
+    pub header: BiometricHeader<S>,
     pub data:   BiometricData,
 }
+
+/// Trait for Biometric sub-types
+pub trait BiometricSubtyped: EncodeValue + for<'a> DecodeValue<'a> + der::FixedTag {}
 
 /// Biometric Header Template (BHT)
 #[derive(Debug, Clone, PartialEq, Eq, Sequence)]
 #[asn1(tag_mode = "IMPLICIT")]
-pub struct BiometricHeader {
+pub struct BiometricHeader<S: BiometricSubtyped = BiometricSubtype> {
     /// ICAO header version. CBEFF patron header format (0101)
     #[asn1(context_specific = "0", optional = "true")]
     pub version:       Option<OctetString>, // '02' length
@@ -30,8 +36,8 @@ pub struct BiometricHeader {
     #[asn1(context_specific = "1", optional = "true")]
     pub btype:         Option<OctetString>, // '01-03' length
     /// Biometric sub-type
-    #[asn1(context_specific = "2", optional = "true")]
-    pub bsubtype:      Option<OctetString>, // '01' length
+    //#[asn1(context_specific = "2", optional = "true")]
+    pub bsubtype: S, // '01' length
     /// Creation date and time
     #[asn1(context_specific = "3", optional = "true")]
     pub creation_date: Option<OctetString>, // '07' length
@@ -63,7 +69,58 @@ pub enum BiometricDataEncoding {
     Iso39794,
 }
 
-impl Encode for BiometricInformationGroup {
+/// Generic Biometric sub-type used in the [`BiometricHeader`].
+/// Is an optional OCTET STRING.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BiometricSubtype(Option<OctetString>);
+
+/// Used to identify the side of a hand (DG3) or iris (DG4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    NoInformation = 0b00,
+    Right         = 0b01,
+    Left          = 0b10,
+}
+
+impl BiometricSubtype {
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        self.0.as_ref().map(|os| os.as_bytes())
+    }
+}
+
+impl der::FixedTag for BiometricSubtype {
+    const TAG: der::Tag = der::Tag::ContextSpecific {
+        constructed: false,
+        number:      der::TagNumber::new(2),
+    };
+}
+impl BiometricSubtyped for BiometricSubtype {}
+
+impl EncodeValue for BiometricSubtype {
+    fn value_len(&self) -> der::Result<Length> {
+        if let Some(os) = &self.0 {
+            os.value_len()
+        } else {
+            Ok(Length::new(0))
+        }
+    }
+
+    fn encode_value(&self, encoder: &mut impl Writer) -> der::Result<()> {
+        if let Some(os) = &self.0 {
+            os.encode_value(encoder)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> DecodeValue<'a> for BiometricSubtype {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, h: der::Header) -> der::Result<Self> {
+        let bytes = reader.read_slice(h.length)?;
+        Ok(Self(Some(OctetString::new(bytes)?)))
+    }
+}
+
+impl<S: BiometricSubtyped> Encode for BiometricInformationGroup<S> {
     fn encoded_len(&self) -> der::Result<Length> {
         todo!("Biometric Information Group encoding not supported yet");
     }
@@ -75,7 +132,7 @@ impl Encode for BiometricInformationGroup {
 
 // The `der` crate currently only supports single-octet tags, so we parse some
 // stuff manually.
-impl<'a> Decode<'a> for BiometricInformationGroup {
+impl<'a, S: BiometricSubtyped> Decode<'a> for BiometricInformationGroup<S> {
     fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
         let tag_7f61 = reader.read_slice(Length::new(2))?;
         if tag_7f61 != &[0x7f, 0x61] {
@@ -127,13 +184,13 @@ impl<'a> Decode<'a> for BiometricInformationGroup {
     }
 }
 
-impl<const TAG: u8> BiometricInformationGroupTagged<TAG> {
-    pub fn infos(&self) -> &[BiometricInformation] {
+impl<const TAG: u8, S: BiometricSubtyped> BiometricInformationGroupTagged<TAG, S> {
+    pub fn infos(&self) -> &[BiometricInformation<S>] {
         &self.0 .0
     }
 }
 
-impl<const TAG: u8> Encode for BiometricInformationGroupTagged<TAG> {
+impl<const TAG: u8, S: BiometricSubtyped> Encode for BiometricInformationGroupTagged<TAG, S> {
     fn encoded_len(&self) -> der::Result<Length> {
         self.0.encoded_len()
     }
@@ -143,7 +200,9 @@ impl<const TAG: u8> Encode for BiometricInformationGroupTagged<TAG> {
     }
 }
 
-impl<'a, const TAG: u8> Decode<'a> for BiometricInformationGroupTagged<TAG> {
+impl<'a, const TAG: u8, S: BiometricSubtyped> Decode<'a>
+    for BiometricInformationGroupTagged<TAG, S>
+{
     fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
         let tag_byte = reader.read_byte()?;
         if tag_byte != TAG {
@@ -152,5 +211,15 @@ impl<'a, const TAG: u8> Decode<'a> for BiometricInformationGroupTagged<TAG> {
         Length::decode(reader)?;
 
         Ok(Self(BiometricInformationGroup::decode(reader)?))
+    }
+}
+
+impl Side {
+    pub fn from_bits(bits: u8) -> Self {
+        match bits & 0b11 {
+            0b01 => Side::Right,
+            0b10 => Side::Left,
+            _ => Side::NoInformation,
+        }
     }
 }

--- a/src/asn1/emrtd/datagroups/biometric.rs
+++ b/src/asn1/emrtd/datagroups/biometric.rs
@@ -1,0 +1,156 @@
+use der::{
+    self, asn1::OctetString, Decode, DecodeValue, Encode, Error, ErrorKind, Length, Reader,
+    Sequence, Writer,
+};
+
+/// Biometric Information Template Group
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BiometricInformationGroup(Vec<BiometricInformation>);
+
+/// Codec helper for Data Groups which employ Biometric Information Template
+/// Groups
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BiometricInformationGroupTagged<const TAG: u8>(BiometricInformationGroup);
+
+/// Biometric Information Template
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BiometricInformation {
+    pub header: BiometricHeader,
+    pub data:   BiometricData,
+}
+
+/// Biometric Header Template (BHT)
+#[derive(Debug, Clone, PartialEq, Eq, Sequence)]
+#[asn1(tag_mode = "IMPLICIT")]
+pub struct BiometricHeader {
+    /// ICAO header version. CBEFF patron header format (0101)
+    #[asn1(context_specific = "0", optional = "true")]
+    pub version:       Option<OctetString>, // '02' length
+    /// Biometric type
+    #[asn1(context_specific = "1", optional = "true")]
+    pub btype:         Option<OctetString>, // '01-03' length
+    /// Biometric sub-type
+    #[asn1(context_specific = "2", optional = "true")]
+    pub bsubtype:      Option<OctetString>, // '01' length
+    /// Creation date and time
+    #[asn1(context_specific = "3", optional = "true")]
+    pub creation_date: Option<OctetString>, // '07' length
+    /// Validity period
+    #[asn1(context_specific = "5", optional = "true")]
+    pub validity:      Option<OctetString>, // '08' length
+    /// Creator of the biometric reference data (PID)
+    #[asn1(context_specific = "6", optional = "true")]
+    pub creator:       Option<OctetString>, // '04' length
+    /// Format owner
+    #[asn1(context_specific = "7")]
+    pub format_owner:  OctetString, // '02' length
+    /// Format type
+    #[asn1(context_specific = "8")]
+    pub format_type:   OctetString, // '02' length
+}
+
+/// Biometric Data Block (BDB)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BiometricData {
+    pub encoding: BiometricDataEncoding,
+    pub bytes:    Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BiometricDataEncoding {
+    Iso19794,
+    // TODO ISO 39794 can be further DER-decoded
+    Iso39794,
+}
+
+impl Encode for BiometricInformationGroup {
+    fn encoded_len(&self) -> der::Result<Length> {
+        todo!("Biometric Information Group encoding not supported yet");
+    }
+
+    fn encode(&self, _encoder: &mut impl Writer) -> der::Result<()> {
+        todo!("Biometric Information Group encoding not supported yet");
+    }
+}
+
+// The `der` crate currently only supports single-octet tags, so we parse some
+// stuff manually.
+impl<'a> Decode<'a> for BiometricInformationGroup {
+    fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
+        let tag_7f61 = reader.read_slice(Length::new(2))?;
+        if tag_7f61 != &[0x7f, 0x61] {
+            return Err(Error::new(ErrorKind::TagNumberInvalid, reader.position()));
+        };
+        Length::decode(reader)?;
+
+        let no_inst = u8::decode(reader)?; // 1 to 9 encodings
+        let mut insts = Vec::with_capacity(no_inst as usize);
+
+        for _ in 0..no_inst {
+            let tag_7f60 = reader.read_slice(Length::new(2))?;
+            if tag_7f60 != &[0x7f, 0x60] {
+                return Err(Error::new(ErrorKind::TagNumberInvalid, reader.position()));
+            };
+            Length::decode(reader)?;
+
+            let header = {
+                let tag_a1 = reader.read_byte()?;
+                if tag_a1 != 0xa1 {
+                    return Err(Error::new(ErrorKind::TagNumberInvalid, reader.position()));
+                };
+                let len = Length::decode(reader)?;
+
+                BiometricHeader::decode_value(reader, der::Header {
+                    tag:    der::Tag::Null, // 0xa1
+                    length: len,
+                })?
+            };
+
+            let data = {
+                let tag_xf2e = reader.read_slice(Length::new(2))?;
+                let encoding = match tag_xf2e {
+                    &[0x5f, 0x2e] => BiometricDataEncoding::Iso19794,
+                    &[0x7f, 0x2e] => BiometricDataEncoding::Iso39794,
+                    _ => return Err(Error::new(ErrorKind::TagNumberInvalid, reader.position())),
+                };
+                let len = Length::decode(reader)?;
+                BiometricData {
+                    encoding,
+                    bytes: reader.read_vec(len)?,
+                }
+            };
+
+            insts.push(BiometricInformation { header, data });
+        }
+
+        Ok(Self(insts))
+    }
+}
+
+impl<const TAG: u8> BiometricInformationGroupTagged<TAG> {
+    pub fn infos(&self) -> &[BiometricInformation] {
+        &self.0 .0
+    }
+}
+
+impl<const TAG: u8> Encode for BiometricInformationGroupTagged<TAG> {
+    fn encoded_len(&self) -> der::Result<Length> {
+        self.0.encoded_len()
+    }
+
+    fn encode(&self, encoder: &mut impl Writer) -> der::Result<()> {
+        self.0.encode(encoder)
+    }
+}
+
+impl<'a, const TAG: u8> Decode<'a> for BiometricInformationGroupTagged<TAG> {
+    fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
+        let tag_byte = reader.read_byte()?;
+        if tag_byte != TAG {
+            return Err(Error::new(ErrorKind::TagNumberInvalid, reader.position()));
+        };
+        Length::decode(reader)?;
+
+        Ok(Self(BiometricInformationGroup::decode(reader)?))
+    }
+}

--- a/src/asn1/emrtd/datagroups/dg2.rs
+++ b/src/asn1/emrtd/datagroups/dg2.rs
@@ -7,10 +7,10 @@ use {
 ///
 /// See ICAO-9303-10 4.7.2
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EfDg2(BiometricInformationGroupTagged<0x75>);
+pub struct EfDg2(BiometricInformationGroupTagged<0x75, BiometricSubtype>);
 
 impl EfDg2 {
-    pub fn infos(&self) -> &[BiometricInformation] {
+    pub fn infos(&self) -> &[BiometricInformation<BiometricSubtype>] {
         &self.0.infos()
     }
 }

--- a/src/asn1/emrtd/datagroups/dg3.rs
+++ b/src/asn1/emrtd/datagroups/dg3.rs
@@ -42,6 +42,12 @@ impl EfDg3 {
     }
 }
 
+impl BiometricInformation<BiometricFinger> {
+    pub fn finger(&self) -> BiometricFinger {
+        self.header.bsubtype
+    }
+}
+
 impl BiometricFinger {
     pub fn from_byte(byte: u8) -> Self {
         let side_bits = byte & 0b11;

--- a/src/asn1/emrtd/datagroups/dg3.rs
+++ b/src/asn1/emrtd/datagroups/dg3.rs
@@ -3,19 +3,19 @@ use {
     der::{self, Decode, Encode, Length, Reader, Writer},
 };
 
-/// EF.DG2 contains biometric data (face).
+/// EF.DG3 (optional) contains biometric data (finger).
 ///
-/// See ICAO-9303-10 4.7.2
+/// See ICAO-9303-10 4.7.3
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EfDg2(BiometricInformationGroupTagged<0x75>);
+pub struct EfDg3(BiometricInformationGroupTagged<0x63>);
 
-impl EfDg2 {
+impl EfDg3 {
     pub fn infos(&self) -> &[BiometricInformation] {
         &self.0.infos()
     }
 }
 
-impl Encode for EfDg2 {
+impl Encode for EfDg3 {
     fn encoded_len(&self) -> der::Result<Length> {
         self.0.encoded_len()
     }
@@ -25,7 +25,7 @@ impl Encode for EfDg2 {
     }
 }
 
-impl<'a> Decode<'a> for EfDg2 {
+impl<'a> Decode<'a> for EfDg3 {
     fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
         let group = BiometricInformationGroupTagged::decode(reader)?;
         Ok(Self(group))

--- a/src/asn1/emrtd/datagroups/dg3.rs
+++ b/src/asn1/emrtd/datagroups/dg3.rs
@@ -1,17 +1,99 @@
 use {
     super::biometric::*,
-    der::{self, Decode, Encode, Length, Reader, Writer},
+    anyhow::anyhow,
+    der::{
+        self, asn1::OctetString, Decode, DecodeValue, Encode, EncodeValue, Error, ErrorKind,
+        Length, Reader, Writer,
+    },
 };
 
 /// EF.DG3 (optional) contains biometric data (finger).
 ///
 /// See ICAO-9303-10 4.7.3
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EfDg3(BiometricInformationGroupTagged<0x63>);
+pub struct EfDg3(BiometricInformationGroupTagged<0x63, BiometricFinger>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BiometricFinger {
+    pub side:   Side,
+    pub finger: Finger,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandSide {
+    NoInformation = 0b00,
+    Right         = 0b01,
+    Left          = 0b10,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Finger {
+    NoInformation = 0b000,
+    Thumb         = 0b001,
+    Pointer       = 0b010,
+    Middle        = 0b011,
+    Ring          = 0b100,
+    Little        = 0b101,
+}
 
 impl EfDg3 {
-    pub fn infos(&self) -> &[BiometricInformation] {
+    pub fn infos(&self) -> &[BiometricInformation<BiometricFinger>] {
         &self.0.infos()
+    }
+}
+
+impl BiometricFinger {
+    pub fn from_byte(byte: u8) -> Self {
+        let side_bits = byte & 0b11;
+        let finger_bits = (byte >> 2) & 0b111;
+        Self {
+            side:   Side::from_bits(side_bits),
+            finger: Finger::from_bits(finger_bits),
+        }
+    }
+
+    pub fn to_byte(&self) -> u8 {
+        0x00 | self.side as u8 | ((self.finger as u8) << 2)
+    }
+}
+
+impl EncodeValue for BiometricFinger {
+    fn value_len(&self) -> der::Result<Length> {
+        OctetString::value_len(&OctetString::new(&[0])?)
+    }
+
+    fn encode_value(&self, encoder: &mut impl Writer) -> der::Result<()> {
+        OctetString::encode_value(&OctetString::new(&[self.to_byte()])?, encoder)
+    }
+}
+
+impl<'a> DecodeValue<'a> for BiometricFinger {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, h: der::Header) -> der::Result<Self> {
+        // input OCTET STRING bytes value
+        let bytes = reader.read_slice(h.length)?;
+        Ok(BiometricFinger::from_byte(bytes.last().copied().unwrap()))
+    }
+}
+
+impl der::FixedTag for BiometricFinger {
+    const TAG: der::Tag = der::Tag::ContextSpecific {
+        constructed: false,
+        number:      der::TagNumber::new(2),
+    };
+}
+
+impl BiometricSubtyped for BiometricFinger {}
+
+impl Finger {
+    pub fn from_bits(bits: u8) -> Self {
+        match bits & 0b111 {
+            0b001 => Finger::Thumb,
+            0b010 => Finger::Pointer,
+            0b011 => Finger::Middle,
+            0b100 => Finger::Ring,
+            0b101 => Finger::Little,
+            _ => Finger::NoInformation,
+        }
     }
 }
 

--- a/src/asn1/emrtd/datagroups/dg4.rs
+++ b/src/asn1/emrtd/datagroups/dg4.rs
@@ -1,19 +1,66 @@
 use {
     super::biometric::*,
-    der::{self, Decode, Encode, Length, Reader, Writer},
+    der::{
+        self, asn1::OctetString, Decode, DecodeValue, Encode, EncodeValue, Length, Reader, Writer,
+    },
 };
 
 /// EF.DG4 contains biometric data (iris).
 ///
 /// See ICAO-9303-10 4.7.4
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EfDg4(BiometricInformationGroupTagged<0x76>);
+pub struct EfDg4(BiometricInformationGroupTagged<0x76, BiometricIris>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BiometricIris {
+    pub side: Side,
+}
 
 impl EfDg4 {
-    pub fn infos(&self) -> &[BiometricInformation] {
+    pub fn infos(&self) -> &[BiometricInformation<BiometricIris>] {
         &self.0.infos()
     }
 }
+
+impl BiometricIris {
+    pub fn from_byte(byte: u8) -> Self {
+        let side_bits = byte & 0b11;
+        Self {
+            side: Side::from_bits(side_bits),
+        }
+    }
+
+    pub fn to_byte(&self) -> u8 {
+        self.side as u8
+    }
+}
+
+impl EncodeValue for BiometricIris {
+    fn value_len(&self) -> der::Result<Length> {
+        OctetString::value_len(&OctetString::new(&[0])?)
+    }
+
+    fn encode_value(&self, encoder: &mut impl Writer) -> der::Result<()> {
+        OctetString::encode_value(&OctetString::new(&[self.to_byte()])?, encoder)
+    }
+}
+
+impl<'a> DecodeValue<'a> for BiometricIris {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, h: der::Header) -> der::Result<Self> {
+        // input OCTET STRING bytes value
+        let bytes = reader.read_slice(h.length)?;
+        Ok(BiometricIris::from_byte(bytes.last().copied().unwrap()))
+    }
+}
+
+impl der::FixedTag for BiometricIris {
+    const TAG: der::Tag = der::Tag::ContextSpecific {
+        constructed: false,
+        number:      der::TagNumber::new(2),
+    };
+}
+
+impl BiometricSubtyped for BiometricIris {}
 
 impl Encode for EfDg4 {
     fn encoded_len(&self) -> der::Result<Length> {

--- a/src/asn1/emrtd/datagroups/dg4.rs
+++ b/src/asn1/emrtd/datagroups/dg4.rs
@@ -3,19 +3,19 @@ use {
     der::{self, Decode, Encode, Length, Reader, Writer},
 };
 
-/// EF.DG2 contains biometric data (face).
+/// EF.DG4 contains biometric data (iris).
 ///
-/// See ICAO-9303-10 4.7.2
+/// See ICAO-9303-10 4.7.4
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EfDg2(BiometricInformationGroupTagged<0x75>);
+pub struct EfDg4(BiometricInformationGroupTagged<0x76>);
 
-impl EfDg2 {
+impl EfDg4 {
     pub fn infos(&self) -> &[BiometricInformation] {
         &self.0.infos()
     }
 }
 
-impl Encode for EfDg2 {
+impl Encode for EfDg4 {
     fn encoded_len(&self) -> der::Result<Length> {
         self.0.encoded_len()
     }
@@ -25,7 +25,7 @@ impl Encode for EfDg2 {
     }
 }
 
-impl<'a> Decode<'a> for EfDg2 {
+impl<'a> Decode<'a> for EfDg4 {
     fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
         let group = BiometricInformationGroupTagged::decode(reader)?;
         Ok(Self(group))

--- a/src/asn1/emrtd/datagroups/dg4.rs
+++ b/src/asn1/emrtd/datagroups/dg4.rs
@@ -22,6 +22,12 @@ impl EfDg4 {
     }
 }
 
+impl BiometricInformation<BiometricIris> {
+    pub fn iris(&self) -> BiometricIris {
+        self.header.bsubtype
+    }
+}
+
 impl BiometricIris {
     pub fn from_byte(byte: u8) -> Self {
         let side_bits = byte & 0b11;

--- a/src/asn1/emrtd/datagroups/mod.rs
+++ b/src/asn1/emrtd/datagroups/mod.rs
@@ -1,7 +1,7 @@
-mod biometric;
+pub mod biometric;
 mod dg1;
 mod dg2;
 mod dg3;
 mod dg4;
 
-pub use {biometric::*, dg1::*, dg2::*, dg3::*, dg4::*};
+pub use {dg1::*, dg2::*, dg3::*, dg4::*};

--- a/src/asn1/emrtd/datagroups/mod.rs
+++ b/src/asn1/emrtd/datagroups/mod.rs
@@ -1,4 +1,7 @@
+mod biometric;
 mod dg1;
 mod dg2;
+mod dg3;
+mod dg4;
 
-pub use {dg1::*, dg2::*};
+pub use {biometric::*, dg1::*, dg2::*, dg3::*, dg4::*};

--- a/src/asn1/emrtd/mod.rs
+++ b/src/asn1/emrtd/mod.rs
@@ -1,4 +1,4 @@
-mod datagroups;
+pub mod datagroups;
 pub mod security_info;
 
 pub use datagroups::*;

--- a/src/emrtd/files/mod.rs
+++ b/src/emrtd/files/mod.rs
@@ -4,7 +4,7 @@ pub use self::file_id::{DedicatedId, FileId};
 use {
     super::{Emrtd, Error, Result},
     crate::{
-        asn1::emrtd::{EfCardAccess, EfDg1, EfDg2, EfDg14, EfSod},
+        asn1::emrtd::{EfCardAccess, EfDg1, EfDg14, EfDg2, EfSod},
         ensure_err,
         iso7816::StatusWord,
     },

--- a/src/emrtd/files/mod.rs
+++ b/src/emrtd/files/mod.rs
@@ -4,7 +4,7 @@ pub use self::file_id::{DedicatedId, FileId};
 use {
     super::{Emrtd, Error, Result},
     crate::{
-        asn1::emrtd::{EfCardAccess, EfDg1, EfDg14, EfDg2, EfSod},
+        asn1::emrtd::{EfCardAccess, EfDg1, EfDg14, EfDg2, EfDg3, EfDg4, EfSod},
         ensure_err,
         iso7816::StatusWord,
     },
@@ -32,6 +32,14 @@ impl HasFileId for EfDg1 {
 
 impl HasFileId for EfDg2 {
     const FILE_ID: FileId = FileId::Dg2;
+}
+
+impl HasFileId for EfDg3 {
+    const FILE_ID: FileId = FileId::Dg3;
+}
+
+impl HasFileId for EfDg4 {
+    const FILE_ID: FileId = FileId::Dg4;
 }
 
 impl HasFileId for EfDg14 {

--- a/tests/test_decode.rs
+++ b/tests/test_decode.rs
@@ -44,13 +44,13 @@ fn test_decode_dg3() -> Result<()> {
     let right = &dg3.infos()[0];
     assert_eq!(right.header.btype.as_ref().unwrap().as_bytes(), &hex!("08"));
     assert_eq!(right.header.format_owner.as_bytes(), &hex!("01 01"));
-    assert_eq!(right.header.bsubtype.side, Side::Right);
-    assert_eq!(right.header.bsubtype.finger, Finger::Pointer);
+    assert_eq!(right.finger().side, Side::Right);
+    assert_eq!(right.finger().finger, Finger::Pointer);
     let left = &dg3.infos()[1];
     assert_eq!(left.header.btype.as_ref().unwrap().as_bytes(), &hex!("08"));
     assert_eq!(left.header.format_owner.as_bytes(), &hex!("01 01"));
-    assert_eq!(left.header.bsubtype.side, Side::Left);
-    assert_eq!(left.header.bsubtype.finger, Finger::Pointer);
+    assert_eq!(left.finger().side, Side::Left);
+    assert_eq!(left.finger().finger, Finger::Pointer);
     Ok(())
 }
 
@@ -61,11 +61,11 @@ fn test_decode_dg4() -> Result<()> {
     let right = &dg4.infos()[0];
     assert_eq!(right.header.btype.as_ref().unwrap().as_bytes(), &hex!("10"));
     assert_eq!(right.header.format_owner.as_bytes(), &hex!("01 01"));
-    assert_eq!(right.header.bsubtype.side, Side::Right);
+    assert_eq!(right.iris().side, Side::Right);
     let left = &dg4.infos()[1];
     assert_eq!(left.header.btype.as_ref().unwrap().as_bytes(), &hex!("10"));
     assert_eq!(left.header.format_owner.as_bytes(), &hex!("01 01"));
-    assert_eq!(left.header.bsubtype.side, Side::Left);
+    assert_eq!(left.iris().side, Side::Left);
     Ok(())
 }
 

--- a/tests/test_decode.rs
+++ b/tests/test_decode.rs
@@ -7,7 +7,10 @@ use {
     der::Decode,
     hex_literal::hex,
     icao_9303::asn1::{
-        emrtd::{security_info::SecurityInfo, EfDg1, EfDg14, EfDg2, EfDg3, EfDg4, EfSod},
+        emrtd::{
+            biometric::Side, security_info::SecurityInfo, EfDg1, EfDg14, EfDg2, EfDg3, EfDg4,
+            EfSod, Finger,
+        },
         DigestAlgorithmIdentifier,
     },
 };
@@ -40,18 +43,14 @@ fn test_decode_dg3() -> Result<()> {
     let dg3 = EfDg3::from_der(&dataset.dg3)?;
     let right = &dg3.infos()[0];
     assert_eq!(right.header.btype.as_ref().unwrap().as_bytes(), &hex!("08"));
-    assert_eq!(
-        right.header.bsubtype.as_ref().unwrap().as_bytes(),
-        &hex!("09")
-    );
     assert_eq!(right.header.format_owner.as_bytes(), &hex!("01 01"));
+    assert_eq!(right.header.bsubtype.side, Side::Right);
+    assert_eq!(right.header.bsubtype.finger, Finger::Pointer);
     let left = &dg3.infos()[1];
     assert_eq!(left.header.btype.as_ref().unwrap().as_bytes(), &hex!("08"));
-    assert_eq!(
-        left.header.bsubtype.as_ref().unwrap().as_bytes(),
-        &hex!("0A")
-    );
     assert_eq!(left.header.format_owner.as_bytes(), &hex!("01 01"));
+    assert_eq!(left.header.bsubtype.side, Side::Left);
+    assert_eq!(left.header.bsubtype.finger, Finger::Pointer);
     Ok(())
 }
 
@@ -62,17 +61,11 @@ fn test_decode_dg4() -> Result<()> {
     let right = &dg4.infos()[0];
     assert_eq!(right.header.btype.as_ref().unwrap().as_bytes(), &hex!("10"));
     assert_eq!(right.header.format_owner.as_bytes(), &hex!("01 01"));
-    assert_eq!(
-        right.header.bsubtype.as_ref().unwrap().as_bytes(),
-        &hex!("01")
-    );
+    assert_eq!(right.header.bsubtype.side, Side::Right);
     let left = &dg4.infos()[1];
     assert_eq!(left.header.btype.as_ref().unwrap().as_bytes(), &hex!("10"));
     assert_eq!(left.header.format_owner.as_bytes(), &hex!("01 01"));
-    assert_eq!(
-        left.header.bsubtype.as_ref().unwrap().as_bytes(),
-        &hex!("02")
-    );
+    assert_eq!(left.header.bsubtype.side, Side::Left);
     Ok(())
 }
 

--- a/tests/test_decode.rs
+++ b/tests/test_decode.rs
@@ -7,7 +7,7 @@ use {
     der::Decode,
     hex_literal::hex,
     icao_9303::asn1::{
-        emrtd::{security_info::SecurityInfo, EfDg1, EfDg14, EfDg2, EfSod},
+        emrtd::{security_info::SecurityInfo, EfDg1, EfDg14, EfDg2, EfDg3, EfDg4, EfSod},
         DigestAlgorithmIdentifier,
     },
 };
@@ -31,6 +31,48 @@ fn test_decode_dg2() -> Result<()> {
     assert_eq!(info.header.btype.as_ref().unwrap().as_bytes(), &hex!("02"));
     assert_eq!(info.header.format_owner.as_bytes(), &hex!("01 01"));
     assert_eq!(info.header.format_type.as_bytes(), &hex!("00 08"));
+    Ok(())
+}
+
+#[test]
+fn test_decode_dg3() -> Result<()> {
+    let dataset = Dataset::load()?;
+    let dg3 = EfDg3::from_der(&dataset.dg3)?;
+    let right = &dg3.infos()[0];
+    assert_eq!(right.header.btype.as_ref().unwrap().as_bytes(), &hex!("08"));
+    assert_eq!(
+        right.header.bsubtype.as_ref().unwrap().as_bytes(),
+        &hex!("09")
+    );
+    assert_eq!(right.header.format_owner.as_bytes(), &hex!("01 01"));
+    let left = &dg3.infos()[1];
+    assert_eq!(left.header.btype.as_ref().unwrap().as_bytes(), &hex!("08"));
+    assert_eq!(
+        left.header.bsubtype.as_ref().unwrap().as_bytes(),
+        &hex!("0A")
+    );
+    assert_eq!(left.header.format_owner.as_bytes(), &hex!("01 01"));
+    Ok(())
+}
+
+#[test]
+fn test_decode_dg4() -> Result<()> {
+    let dataset = Dataset::load()?;
+    let dg4 = EfDg4::from_der(&dataset.dg4)?;
+    let right = &dg4.infos()[0];
+    assert_eq!(right.header.btype.as_ref().unwrap().as_bytes(), &hex!("10"));
+    assert_eq!(right.header.format_owner.as_bytes(), &hex!("01 01"));
+    assert_eq!(
+        right.header.bsubtype.as_ref().unwrap().as_bytes(),
+        &hex!("01")
+    );
+    let left = &dg4.infos()[1];
+    assert_eq!(left.header.btype.as_ref().unwrap().as_bytes(), &hex!("10"));
+    assert_eq!(left.header.format_owner.as_bytes(), &hex!("01 01"));
+    assert_eq!(
+        left.header.bsubtype.as_ref().unwrap().as_bytes(),
+        &hex!("02")
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Adds decoding of EFs DG3 and DG4 which contain biometric data: fingers, and iris, respectively.

DG2, DG3, and DG4 are all encoded using the same base format "Biometric Information Template Group Template".
Some smaller sub-encodings specific to each DG can be also added, e.g., right vs left finger (for DG3) differentiated in the header's sub-type.